### PR TITLE
40k: fix some weapon corner cases

### DIFF
--- a/spec/AeldariTestSpec.ts
+++ b/spec/AeldariTestSpec.ts
@@ -19,7 +19,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Farseer"}),
               ],
               '_modelList': [
-                "Farseer (Shuriken pistol, Witchblade, Ghosthelm, Rune Armour, Runes of the Farseer)"
+                "Farseer (Shuriken Pistol, Witchblade, Ghosthelm, Rune Armour, Runes of the Farseer)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Shuriken pistol"}),
@@ -49,7 +49,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Dire Avenger"}),
               ],
               '_modelList': [
-                "5x Dire Avenger (Avenger Shuriken Catapult, Plasma Grenade)"
+                "5x Dire Avenger (Avenger Shuriken Catapult, Plasma Grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Avenger Shuriken Catapult"}),
@@ -61,7 +61,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Ranger"}),
               ],
               '_modelList': [
-                "5x Ranger (Ranger Long Rifle, Shuriken pistol)"
+                "5x Ranger (Ranger Long Rifle, Shuriken Pistol)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Ranger Long Rifle"}),
@@ -73,7 +73,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Storm Guardian"}),
               ],
               '_modelList': [
-                "8x Storm Guardian - Aeldari Blade (Shuriken pistol, Aeldari Blade, Plasma Grenade)"
+                "8x Storm Guardian - Aeldari Blade (Shuriken Pistol, Aeldari Blade, Plasma Grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Shuriken pistol"}),
@@ -120,7 +120,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Crimson Hunter Exarch"}),
               ],
               '_modelList': [
-                "Crimson Hunter Exarch (Bright Lance, Pulse Laser, Airborne, Crash and Burn, Hard To Hit, Skyhunters, Wings of Khaine)"
+                "Crimson Hunter Exarch (Two Bright Lances, Pulse Laser, Airborne, Crash and Burn, Hard To Hit, Skyhunters, Wings of Khaine)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bright Lance"}),
@@ -139,7 +139,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Succubus"}),
               ],
               '_modelList': [
-                "Succubus (Splinter pistol, Archite glaive)"
+                "Succubus (Splinter pistol, Archite Glaive)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Splinter pistol"}),
@@ -165,8 +165,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Sybarite"}),
               ],
               '_modelList': [
-                "4x Kabalite Warrior (Splinter rifle)",
-                "Sybarite (Splinter rifle)"
+                "4x Kabalite Warrior (Splinter Rifle)",
+                "Sybarite (Splinter Rifle)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Splinter rifle"}),
@@ -179,7 +179,7 @@ describe("Create40kRoster", function() {
               ],
               '_modelList': [
                 "Acothyst (Haemonculus tools)",
-                "4x Wracks (Haemonculus tools)"
+                "4x Wracks (Haemonculus Tools)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Haemonculus tools"}),
@@ -192,7 +192,7 @@ describe("Create40kRoster", function() {
               ],
               '_modelList': [
                 "Hekatrix (Splinter pistol, Hekatarii blade, Plasma Grenade)",
-                "4x Wych (Splinter pistol, Hekatarii blade, Plasma Grenade)"
+                "4x Wych (Splinter Pistol, Hekatarii blade, Plasma Grenade)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Splinter pistol"}),
@@ -250,7 +250,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Reaper"}),
               ],
               '_modelList': [
-                "Reaper (Storm Vortex Projector - Beam, Storm Vortex Projector - Blast, Scythevanes, Sharpened prow blade, Night Shield, Storm Vortex Projector)"
+                "Reaper (Storm Vortex Projector, Scythevanes, Sharpened prow blade, Night Shield, Storm Vortex Projector)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Storm Vortex Projector - Beam"}),

--- a/spec/AeldariTestSpec.ts
+++ b/spec/AeldariTestSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Aeldari Test.ros", function() {
-    const doc = readRosterFile('test/Aeldari Test.ros');
+  it("loads test/Aeldari Test.ros", async function() {
+    const doc = await readZippedRosterFile('test/Aeldari Test.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/BlackTemplar-TestOutputSpec.ts
+++ b/spec/BlackTemplar-TestOutputSpec.ts
@@ -19,7 +19,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Chapter Master in Phobos Armor (Stratagem: Chapter Master)"}),
               ],
               '_modelList': [
-                "Chapter Master in Phobos Armor (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag grenade, Krak grenade, Camo cloak, Frontline Commander)"
+                "Chapter Master in Phobos Armor (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Frontline Commander)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -34,7 +34,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Primaris Lieutenants"}),
               ],
               '_modelList': [
-                "Primaris Lieutenants (Bolt pistol, Master-crafted auto bolt rifle, Frag grenade, Krak grenade)"
+                "Primaris Lieutenants (Bolt pistol, Master-crafted auto bolt rifle, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -49,7 +49,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Scout Sergeant"}),
               ],
               '_modelList': [
-                "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag grenade, 2x Krak grenade)"
+                "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -64,8 +64,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
               ],
               '_modelList': [
-                "6x Space Marine (7x Bolt pistol, Boltgun, Grav-gun, 7x Frag grenade, 7x Krak grenade)",
-                "Space Marine Sergeant (2x Bolt pistol, Boltgun, Grav-gun, 2x Frag grenade, 2x Krak grenade, Melta bomb)"
+                "6x Space Marine (7x Bolt pistol, Boltgun, Grav-gun, 7x Frag & Krak grenades)",
+                "Space Marine Sergeant (2x Bolt pistol, Boltgun, Grav-gun, 2x Frag & Krak grenades, Melta bombs)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -82,8 +82,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
               ],
               '_modelList': [
-                "4x Space Marine (Bolt pistol, Boltgun, Frag grenade, Krak grenade)",
-                "Space Marine Sergeant (Bolt pistol, Boltgun, Frag grenade, Krak grenade)"
+                "4x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -110,7 +110,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Chaplain Grimaldus"}),
               ],
               '_modelList': [
-                "Chaplain Grimaldus (Plasma pistol, Standard, Plasma pistol, Supercharge, Artificer Crozius, Frag grenade, Krak grenade)"
+                "Chaplain Grimaldus (Plasma pistol, Artificer Crozius, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Plasma pistol, Standard"}),
@@ -125,7 +125,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Emperor's Champion"}),
               ],
               '_modelList': [
-                "The Emperor's Champion (Bolt pistol, Black Sword, Frag grenade, Krak grenade)"
+                "The Emperor's Champion (Bolt pistol, Black Sword, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -140,9 +140,9 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Sword Brother"}),
               ],
               '_modelList': [
-                "3x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag grenade, Krak grenade)",
-                "Initiate w/Heavy or Melee Weapon (Bolt pistol, Lascannon, Frag grenade, Krak grenade)",
-                "Sword Brother (Bolt pistol, Power axe, Frag grenade, Krak grenade)"
+                "3x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
+                "Initiate w/Heavy or Melee Weapon (Bolt pistol, Lascannon, Frag & Krak grenades)",
+                "Sword Brother (Bolt pistol, Power axe, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -160,10 +160,10 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Sword Brother"}),
               ],
               '_modelList': [
-                "4x Initiate (Bolt pistol, Boltgun, Frag grenade, Krak grenade)",
-                "Initiate w/Special Weapon (Bolt pistol, Grav-gun, Frag grenade, Krak grenade)",
-                "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag grenade, Krak grenade)",
-                "Sword Brother (Bolt pistol, Power fist, Frag grenade, Krak grenade)"
+                "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Initiate w/Special Weapon (Bolt pistol, Grav-gun, Frag & Krak grenades)",
+                "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag & Krak grenades)",
+                "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Astartes shotgun"}),
@@ -179,18 +179,16 @@ describe("Create40kRoster", function() {
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Initiate"}),
                 jasmine.objectContaining({'_name': "Neophyte"}),
-                jasmine.objectContaining({'_name': "Neophyte"}),
-                jasmine.objectContaining({'_name': "Neophyte"}),
                 jasmine.objectContaining({'_name': "Sword Brother"}),
               ],
               '_modelList': [
-                "4x Initiate (Bolt pistol, Boltgun, Frag grenade, Krak grenade)",
-                "Initiate w/Chainsword (Bolt pistol, Chainsword, Frag grenade, Krak grenade)",
-                "Initiate w/Heavy or Melee Weapon (Bolt pistol, Heavy bolter, Frag grenade, Krak grenade)",
-                "Neophyte w/Boltgun (Bolt pistol, Boltgun, Frag grenade, Krak grenade)",
-                "Neophyte w/Combat Knife (Bolt pistol, Combat knife, Frag grenade, Krak grenade)",
-                "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag grenade, Krak grenade)",
-                "Sword Brother (Bolt pistol, Power fist, Frag grenade, Krak grenade)"
+                "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
+                "Initiate w/Heavy or Melee Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
+                "Neophyte w/Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Neophyte w/Combat Knife (Bolt pistol, Combat knife, Frag & Krak grenades)",
+                "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag & Krak grenades)",
+                "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Astartes shotgun"}),
@@ -222,7 +220,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
               ],
               '_modelList': [
-                "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag grenade, Krak grenade)"
+                "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -238,7 +236,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Centurion Sergeant"}),
               ],
               '_modelList': [
-                "Centurion Devastator Squad (3x Heavy bolter, 3x Hurricane bolter)"
+                "Centurion Devastator Squad (3x Two Heavy Bolters, 3x Hurricane bolter)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy bolter"}),
@@ -251,7 +249,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
               ],
               '_modelList': [
-                "Devastator Squad (5x Bolt pistol, Grav-cannon and grav-amp, Grav-pistol, 2x Heavy bolter, Multi-melta, Chainsword, 5x Frag grenade, 5x Krak grenade)"
+                "Devastator Squad (5x Bolt pistol, Grav-cannon and grav-amp, Grav-pistol, 2x Heavy bolter, Multi-melta, Chainsword, 5x Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -270,8 +268,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
               ],
               '_modelList': [
-                "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Bolt sniper rifle - Executioner round, Bolt sniper rifle - Hyperfrag round, Bolt sniper rifle - Mortis round, Frag grenade, Krak grenade)",
-                "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Bolt sniper rifle - Executioner round, Bolt sniper rifle - Hyperfrag round, Bolt sniper rifle - Mortis round, Frag grenade, Krak grenade)"
+                "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades)",
+                "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -288,7 +286,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Repulsor Executioner"}),
               ],
               '_modelList': [
-                "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Icarus Rocket Pod, Ironhail Heavy Stubber, Macro Plasma Incinerator, Standard, Macro Plasma Incinerator, Supercharged, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber)"
+                "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Icarus Rocket Pod, Ironhail Heavy Stubber, Macro Plasma Incinerator, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
@@ -323,7 +321,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Repulsor"}),
               ],
               '_modelList': [
-                "Repulsor (Heavy Onslaught Gatling Cannon, Icarus Ironhail Heavy Stubber, 2x Ironhail Heavy Stubber, 2x Krakstorm Grenade Launcher, Storm bolter, Twin heavy bolter)"
+                "Repulsor (Heavy Onslaught Gatling Cannon, Icarus Ironhail Heavy Stubber, 2x Ironhail Heavy Stubber, 2x Krakstorm Grenade Launcher, 2x Storm Bolters, Twin heavy bolter)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),

--- a/spec/BlackTemplar-TestOutputSpec.ts
+++ b/spec/BlackTemplar-TestOutputSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Black Templar - Test Output.ros", function() {
-    const doc = readRosterFile('test/Black Templar - Test Output.ros');
+  it("loads test/Black Templar - Test Output.ros", async function() {
+    const doc = await readZippedRosterFile('test/Black Templar - Test Output.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/BlackTemplar2000Spec.ts
+++ b/spec/BlackTemplar2000Spec.ts
@@ -19,7 +19,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Captain in Phobos Armour"}),
               ],
               '_modelList': [
-                "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag grenade, Krak grenade, Camo cloak, Champion of Humanity)"
+                "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Champion of Humanity)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -34,7 +34,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
               ],
               '_modelList': [
-                "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag grenade, Krak grenade, The Armour Indomitus)"
+                "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag & Krak grenades, The Armour Indomitus)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -49,7 +49,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Emperor's Champion"}),
               ],
               '_modelList': [
-                "The Emperor's Champion (Bolt pistol, Black Sword, Frag grenade, Krak grenade)"
+                "The Emperor's Champion (Bolt pistol, Black Sword, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -64,8 +64,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Sword Brother"}),
               ],
               '_modelList': [
-                "4x Initiate (Bolt pistol, Boltgun, Frag grenade, Krak grenade)",
-                "Sword Brother (Boltgun, Power fist, Frag grenade, Krak grenade)"
+                "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Sword Brother (Boltgun, Power fist, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -81,8 +81,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Infiltrator Sergeant"}),
               ],
               '_modelList': [
-                "4x Infilltrator (Bolt pistol, Marksman bolt carbine, Frag grenade, Krak grenade)",
-                "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag grenade, Krak grenade)"
+                "4x Infilltrator (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)",
+                "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -97,8 +97,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
               ],
               '_modelList': [
-                "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag grenade, Krak grenade)",
-                "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag grenade, Krak grenade)"
+                "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
+                "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Auto Bolt Rifle"}),
@@ -114,8 +114,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Intercessor Sergeant (Veteran Intercessors)"}),
               ],
               '_modelList': [
-                "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag grenade, Krak grenade)",
-                "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag grenade, Krak grenade)"
+                "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
+                "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Auto Bolt Rifle"}),
@@ -131,7 +131,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Scout Sergeant"}),
               ],
               '_modelList': [
-                "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag grenade, 2x Krak grenade)"
+                "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -146,8 +146,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
               ],
               '_modelList': [
-                "4x Space Marine (Bolt pistol, Boltgun, Frag grenade, Krak grenade)",
-                "Space Marine Sergeant (Bolt pistol, Boltgun, Frag grenade, Krak grenade)"
+                "4x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -187,7 +187,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Redemptor Dreadnought"}),
               ],
               '_modelList': [
-                "Redemptor Dreadnought (Fragstorm Grenade Launcher, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
+                "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
@@ -207,7 +207,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
               ],
               '_modelList': [
-                "Assault Squad (2x Bolt pistol, 2x Chainsword, 2x Frag grenade, 2x Krak grenade)"
+                "Assault Squad (2x Bolt pistol/Chainsword, 2x Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -222,7 +222,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
               ],
               '_modelList': [
-                "Assault Squad (2x Bolt pistol, 2x Chainsword, 2x Frag grenade, 2x Krak grenade)"
+                "Assault Squad (2x Bolt pistol/Chainsword, 2x Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -237,8 +237,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Suppressor Sergeant"}),
               ],
               '_modelList': [
-                "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag grenade, Krak grenade, Grav-chute)",
-                "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag grenade, Krak grenade, Grav-chute)"
+                "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)",
+                "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Accelerator autocannon"}),
@@ -253,8 +253,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
               ],
               '_modelList': [
-                "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Bolt sniper rifle - Executioner round, Bolt sniper rifle - Hyperfrag round, Bolt sniper rifle - Mortis round, Frag grenade, Krak grenade)",
-                "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Bolt sniper rifle - Executioner round, Bolt sniper rifle - Hyperfrag round, Bolt sniper rifle - Mortis round, Frag grenade, Krak grenade)"
+                "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades)",
+                "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -271,7 +271,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Predator"}),
               ],
               '_modelList': [
-                "Predator (Heavy bolter, Storm bolter, Twin lascannon)"
+                "Predator (Two Heavy Bolters, Storm bolter, Twin lascannon)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy bolter"}),
@@ -289,7 +289,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Repulsor Executioner"}),
               ],
               '_modelList': [
-                "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Macro Plasma Incinerator, Standard, Macro Plasma Incinerator, Supercharged, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber)"
+                "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Macro Plasma Incinerator, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
@@ -322,7 +322,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Impulsor"}),
               ],
               '_modelList': [
-                "Impulsor (Ironhail Heavy Stubber, Storm bolter, Shield Dome)"
+                "Impulsor (Ironhail Heavy Stubber, 2x Storm Bolters, Shield Dome)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),

--- a/spec/BlackTemplar2000Spec.ts
+++ b/spec/BlackTemplar2000Spec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Black Templar 2000.ros", function() {
-    const doc = readRosterFile('test/Black Templar 2000.ros');
+  it("loads test/Black Templar 2000.ros", async function() {
+    const doc = await readZippedRosterFile('test/Black Templar 2000.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/BloodAngelstestSpec.ts
+++ b/spec/BloodAngelstestSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/BloodAngels test.ros", function() {
-    const doc = readRosterFile('test/BloodAngels test.ros');
+  it("loads test/BloodAngels test.ros", async function() {
+    const doc = await readZippedRosterFile('test/BloodAngels test.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/BloodAngelstestSpec.ts
+++ b/spec/BloodAngelstestSpec.ts
@@ -20,8 +20,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Primaris Lieutenant"}),
               ],
               '_modelList': [
-                "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag grenades, Krak grenades)",
-                "Primaris Lieutenant (Bolt pistol, Neo-volkite pistol, Master-crafted power sword, Frag grenades, Krak grenades)"
+                "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt carbine, Paired Combat Blades, Frag & Krak grenades)",
+                "Primaris Lieutenant (Bolt pistol, Neo-volkite pistol, Master-crafted power sword, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -39,8 +39,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Assault Intercessor Sgt"}),
               ],
               '_modelList': [
-                "4x Assault Intercessor (Heavy Bolt Pistol, Astartes Chainsword, Frag grenades, Krak grenades)",
-                "Assault Intercessor Sgt (Heavy Bolt Pistol, Astartes Chainsword, Frag grenades, Krak grenades)"
+                "4x Assault Intercessor (Heavy Bolt Pistol, Astartes Chainsword, Frag & Krak grenades)",
+                "Assault Intercessor Sgt (Heavy Bolt Pistol, Astartes Chainsword, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
@@ -55,8 +55,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Bladeguard Veteran Sergeant"}),
               ],
               '_modelList': [
-                "2x Bladeguard Veteran (Heavy Bolt Pistol, Master-crafted power sword, Frag grenades, Krak grenades, Storm shield)",
-                "Bladeguard Veteran Sergeant (Heavy Bolt Pistol, Master-crafted power sword, Frag grenades, Krak grenades, Storm shield)"
+                "2x Bladeguard Veteran (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm shield)",
+                "Bladeguard Veteran Sergeant (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm shield)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
@@ -71,8 +71,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Bladeguard Veteran Sergeant"}),
               ],
               '_modelList': [
-                "2x Bladeguard Veteran (Heavy Bolt Pistol, Master-crafted power sword, Frag grenades, Krak grenades, Storm shield)",
-                "Bladeguard Veteran Sergeant (Heavy Bolt Pistol, Master-crafted power sword, Frag grenades, Krak grenades, Storm shield)"
+                "2x Bladeguard Veteran (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm shield)",
+                "Bladeguard Veteran Sergeant (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm shield)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
@@ -87,8 +87,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Outrider Sgt"}),
               ],
               '_modelList': [
-                "2x Outrider (Heavy Bolt Pistol, Twin Bolt rifle, Astartes Chainsword, Frag grenades, Krak grenades)",
-                "Outrider Sgt (Heavy Bolt Pistol, Twin Bolt rifle, Astartes Chainsword, Frag grenades, Krak grenades)"
+                "2x Outrider (Heavy Bolt Pistol, Twin Bolt rifle, Astartes Chainsword, Frag & Krak grenades)",
+                "Outrider Sgt (Heavy Bolt Pistol, Twin Bolt rifle, Astartes Chainsword, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),

--- a/spec/ChaosSMTestSpec.ts
+++ b/spec/ChaosSMTestSpec.ts
@@ -31,7 +31,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Lord Discordant on Helstalker"}),
               ],
               '_modelList': [
-                "Lord Discordant on Helstalker (Autocannon, Bolt pistol, Bladed limbs and tail, Impaler chainglaive, Mechatendrils, Techno-virus injector, Frag grenade, Krak grenade)"
+                "Lord Discordant on Helstalker (Autocannon, Bolt pistol, Bladed limbs and tail, Impaler chainglaive, Mechatendrils, Techno-virus injector, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Autocannon"}),
@@ -55,7 +55,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Sorcerer"}),
               ],
               '_modelList': [
-                "Sorcerer (Bolt pistol, Force sword, Frag grenade, Krak grenade)"
+                "Sorcerer (Bolt pistol, Force sword, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -89,8 +89,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Chaos Space Marine"}),
               ],
               '_modelList': [
-                "Aspiring Champion (Bolt pistol, Boltgun, Frag grenade, Krak grenade)",
-                "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag grenade, Krak grenade)"
+                "Aspiring Champion (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -105,8 +105,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Chaos Space Marine"}),
               ],
               '_modelList': [
-                "Aspiring Champion (Bolt pistol, Boltgun, Frag grenade, Krak grenade)",
-                "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag grenade, Krak grenade)"
+                "Aspiring Champion (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -146,8 +146,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Plague Marine"}),
               ],
               '_modelList': [
-                "Plague Champion (Boltgun, Plague knife, Blight Grenades, Krak grenade)",
-                "4x Plague Marine w/ boltgun (Boltgun, Plague knife, Blight Grenades, Krak grenade)"
+                "Plague Champion (Boltgun, Plague knife, Blight Grenades, Krak grenades)",
+                "4x Plague Marine w/ boltgun (Boltgun, Plague knife, Blight Grenades, Krak Grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Boltgun"}),
@@ -195,7 +195,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Heldrake"}),
               ],
               '_modelList': [
-                "Heldrake (Hades autocannon, Heldrake claws)"
+                "Heldrake (Hades Autocannon, Heldrake claws)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Hades autocannon"}),
@@ -332,7 +332,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Exalted Flamer"}),
               ],
               '_modelList': [
-                "Exalted Flamer (Fire of Tzeentch (Blue), Fire of Tzeentch (Pink), Tongues of flame)"
+                "Exalted Flamer (Fire of Tzeentch, Tongues of flame)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Fire of Tzeentch (Blue)"}),

--- a/spec/ChaosSMTestSpec.ts
+++ b/spec/ChaosSMTestSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Chaos SM Test.ros", function() {
-    const doc = readRosterFile('test/Chaos SM Test.ros');
+  it("loads test/Chaos SM Test.ros", async function() {
+    const doc = await readZippedRosterFile('test/Chaos SM Test.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/DrukariTestSpec.ts
+++ b/spec/DrukariTestSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Drukari Test.ros", function() {
-    const doc = readRosterFile('test/Drukari Test.ros');
+  it("loads test/Drukari Test.ros", async function() {
+    const doc = await readZippedRosterFile('test/Drukari Test.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/DrukariTestSpec.ts
+++ b/spec/DrukariTestSpec.ts
@@ -44,8 +44,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Sybarite"}),
               ],
               '_modelList': [
-                "4x Kabalite Warrior (Splinter rifle)",
-                "Sybarite (Splinter rifle)"
+                "4x Kabalite Warrior (Splinter Rifle)",
+                "Sybarite (Splinter Rifle)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Splinter rifle"}),
@@ -58,7 +58,7 @@ describe("Create40kRoster", function() {
               ],
               '_modelList': [
                 "Acothyst (Haemonculus tools)",
-                "4x Wracks (Haemonculus tools)"
+                "4x Wracks (Haemonculus Tools)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Haemonculus tools"}),
@@ -71,7 +71,7 @@ describe("Create40kRoster", function() {
               ],
               '_modelList': [
                 "Hekatrix (Splinter pistol, Hekatarii blade, Plasma Grenade)",
-                "4x Wych (Splinter pistol, Hekatarii blade, Plasma Grenade)"
+                "4x Wych (Splinter Pistol, Hekatarii blade, Plasma Grenade)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Splinter pistol"}),
@@ -82,11 +82,9 @@ describe("Create40kRoster", function() {
               '_name': "Grotesques",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Grotesque"}),
-                jasmine.objectContaining({'_name': "Grotesque"}),
-                jasmine.objectContaining({'_name': "Grotesque"}),
               ],
               '_modelList': [
-                "3x Grotesque with Monstrous Cleaver (Flesh Gauntlet, Monstrous cleaver)"
+                "3x Grotesque with Monstrous Cleaver (Flesh gauntlet, Monstrous cleaver)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Flesh Gauntlet"}),
@@ -159,7 +157,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Reaper"}),
               ],
               '_modelList': [
-                "Reaper (Storm Vortex Projector - Beam, Storm Vortex Projector - Blast, Scythevanes, Sharpened prow blade, Night Shield, Storm Vortex Projector)"
+                "Reaper (Storm Vortex Projector, Scythevanes, Sharpened prow blade, Night Shield, Storm Vortex Projector)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Storm Vortex Projector - Beam"}),
@@ -179,7 +177,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Voidraven"}),
               ],
               '_modelList': [
-                "Voidraven (Void lance)"
+                "Voidraven (Two void lances)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Void lance"}),
@@ -280,13 +278,9 @@ describe("Create40kRoster", function() {
               '_name': "Troupe",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
               ],
               '_modelList': [
-                "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenade)"
+                "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Shuriken Pistol"}),
@@ -297,13 +291,9 @@ describe("Create40kRoster", function() {
               '_name': "Troupe",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
               ],
               '_modelList': [
-                "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenade)"
+                "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Shuriken Pistol"}),
@@ -314,13 +304,9 @@ describe("Create40kRoster", function() {
               '_name': "Troupe",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
-                jasmine.objectContaining({'_name': "Player"}),
               ],
               '_modelList': [
-                "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenade)"
+                "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Shuriken Pistol"}),
@@ -333,7 +319,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Death Jester"}),
               ],
               '_modelList': [
-                "Death Jester (Shrieker Cannon (Shrieker), Shrieker Cannon (Shuriken))"
+                "Death Jester (Shrieker Cannon)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Shrieker Cannon (Shrieker)"}),
@@ -342,7 +328,6 @@ describe("Create40kRoster", function() {
             jasmine.objectContaining({
               '_name': "Skyweavers",
               '_modelStats': [
-                jasmine.objectContaining({'_name': "Skyweaver"}),
                 jasmine.objectContaining({'_name': "Skyweaver"}),
               ],
               '_modelList': [

--- a/spec/GuardSpec.ts
+++ b/spec/GuardSpec.ts
@@ -33,7 +33,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Knight Commander Pask"}),
               ],
               '_modelList': [
-                "Knight Commander Pask (Battle Cannon, Heavy bolter)"
+                "Knight Commander Pask (Battle Cannon, Heavy Bolter)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Battle Cannon"}),
@@ -50,7 +50,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Sly Marbo"}),
               ],
               '_modelList': [
-                "Sly Marbo (Ripper Pistol, Envenomed Blade, Frag grenade)"
+                "Sly Marbo (Ripper Pistol, Envenomed Blade, Frag Grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Ripper Pistol"}),
@@ -134,14 +134,12 @@ describe("Create40kRoster", function() {
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Tempestor"}),
                 jasmine.objectContaining({'_name': "Tempestus Scion"}),
-                jasmine.objectContaining({'_name': "Tempestus Scion"}),
-                jasmine.objectContaining({'_name': "Tempestus Scion"}),
               ],
               '_modelList': [
-                "4x Scion (Hot-shot Lasgun, Frag grenade, Krak grenade)",
-                "Scion w/ Special Weapon (Grenade Launcher (Frag), Grenade Launcher (Krak), Frag grenade, Krak grenade)",
-                "Scion w/ Vox-caster (Hot-shot Lasgun, Hot-shot Laspistol, Vox-caster)",
-                "Tempestor (Hot-shot Laspistol, Power fist, Frag grenade, Krak grenade)"
+                "4x Scion (Hot-shot Lasgun, Frag & Krak grenades)",
+                "Scion w/ Special Weapon (Grenade Launcher, Frag & Krak grenades)",
+                "Scion w/ Vox-caster (Hot-Shot Lasgun, Hot-shot Laspistol, Vox-caster)",
+                "Tempestor (Hot-shot Laspistol, Power fist, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Grenade Launcher (Frag)"}),
@@ -155,7 +153,6 @@ describe("Create40kRoster", function() {
             jasmine.objectContaining({
               '_name': "Bullgryns",
               '_modelStats': [
-                jasmine.objectContaining({'_name': "Bullgryn"}),
                 jasmine.objectContaining({'_name': "Bullgryn"}),
                 jasmine.objectContaining({'_name': "Bullgryn Bone 'ead"}),
               ],
@@ -176,8 +173,8 @@ describe("Create40kRoster", function() {
               ],
               '_modelList': [
                 "Hades Breaching Drill (Melta Cutter Drill)",
-                "Veteran Sergeant (Laspistol, Chainsword, Frag grenade)",
-                "9x Veteran w/ Shotgun (Shotgun, Frag grenade)"
+                "Veteran Sergeant (Laspistol, Chainsword, Frag Grenades)",
+                "9x Veteran w/ Shotgun (Shotgun, Frag Grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Laspistol"}),
@@ -190,13 +187,10 @@ describe("Create40kRoster", function() {
               '_name': "Special Weapons Squad",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Guardsman"}),
-                jasmine.objectContaining({'_name': "Guardsman"}),
-                jasmine.objectContaining({'_name': "Guardsman"}),
-                jasmine.objectContaining({'_name': "Guardsman"}),
               ],
               '_modelList': [
                 "3x Guardsman (Lasgun, Frag grenade)",
-                "Guardsman W/ Special Weapon (Grenade Launcher (Frag), Grenade Launcher (Krak), Frag grenade)",
+                "Guardsman W/ Special Weapon (Grenade Launcher, Frag grenade)",
                 "Guardsman W/ Special Weapon (Meltagun, Frag grenade)",
                 "Guardsman W/ Special Weapon (Sniper rifle, Frag grenade)"
               ],
@@ -212,13 +206,11 @@ describe("Create40kRoster", function() {
               '_name': "Hellhounds",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Hellhound"}),
-                jasmine.objectContaining({'_name': "Hellhound"}),
-                jasmine.objectContaining({'_name': "Hellhound"}),
               ],
               '_modelList': [
-                "Bane Wolf (Chem Cannon, Heavy bolter)",
-                "Devil Dog (Heavy bolter, Melta Cannon)",
-                "Hellhound (Heavy bolter, Inferno Cannon)"
+                "Bane Wolf (Turret-mounted Chem Cannon, Heavy Bolter)",
+                "Devil Dog (Heavy Bolter, Turret-mounted Melta Cannon)",
+                "Hellhound (Heavy Bolter, Turret-mounted Inferno Cannon)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Chem Cannon"}),
@@ -265,7 +257,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Hydra"}),
               ],
               '_modelList': [
-                "Hydra (Heavy bolter, Hydra Quad Autocannon)"
+                "Hydra (Heavy Bolter, Hydra Quad Autocannon)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy bolter"}),
@@ -283,7 +275,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Rapier"}),
               ],
               '_modelList': [
-                "2x Guardsmen Crew (Lasgun, Frag grenade)",
+                "2x Guardsmen Crew (Lasgun, Frag Grenades)",
                 "Rapier (Laser Destroyer)"
               ],
               '_weapons': [
@@ -297,7 +289,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Wyvern"}),
               ],
               '_modelList': [
-                "Wyvern (Heavy bolter, Wyvern Quad Stormshard Mortar)"
+                "Wyvern (Heavy Bolter, Wyven Quad Stormshard Mortar)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy bolter"}),

--- a/spec/GuardSpec.ts
+++ b/spec/GuardSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Guard.ros", function() {
-    const doc = readRosterFile('test/Guard.ros');
+  it("loads test/Guard.ros", async function() {
+    const doc = await readZippedRosterFile('test/Guard.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/KnightsSpec.ts
+++ b/spec/KnightsSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Knights.ros", function() {
-    const doc = readRosterFile('test/Knights.ros');
+  it("loads test/Knights.ros", async function() {
+    const doc = await readZippedRosterFile('test/Knights.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/KnightsSpec.ts
+++ b/spec/KnightsSpec.ts
@@ -39,7 +39,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Armiger Warglaive"}),
               ],
               '_modelList': [
-                "Armiger Warglaive (Meltagun, Thermal Spear, Reaper Chain-Cleaver (Strike), Reaper Chain-Cleaver (Sweep))"
+                "Armiger Warglaive (Meltagun, Thermal Spear, Reaper Chain-Cleaver)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Meltagun"}),
@@ -61,7 +61,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Knight Castellan"}),
               ],
               '_modelList': [
-                "Knight Castellan (Plasma Decimator (Standard), Plasma Decimator (Supercharge), 2x Shieldbreaker Missile, 2x Twin Meltagun, 2x Twin Siegebreaker Cannon, Volcano Lance, Titanic Feet, Armour of the Sainted Ion, Fearsome Reputation)"
+                "Knight Castellan (Plasma Decimator, 2x Shieldbreaker Missile, 2x Twin Meltagun, 2x Twin Siegebreaker Cannon, Volcano Lance, Titanic Feet, Armour of the Sainted Ion, Fearsome Reputation)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Plasma Decimator (Standard)"}),
@@ -109,7 +109,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Knight Gallant"}),
               ],
               '_modelList': [
-                "Knight Gallant (Heavy stubber, Stormspear Rocket Pod, Reaper Chainsword, Thunderstrike gauntlet, Titanic Feet)"
+                "Knight Gallant (Heavy Stubber, Stormspear Rocket Pod, Reaper Chainsword, Thunderstrike gauntlet, Titanic Feet)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy stubber"}),

--- a/spec/MagnusSpec.ts
+++ b/spec/MagnusSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Magnus.ros", function() {
-    const doc = readRosterFile('test/Magnus.ros');
+  it("loads test/Magnus.ros", async function() {
+    const doc = await readZippedRosterFile('test/Magnus.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/MagnusSpec.ts
+++ b/spec/MagnusSpec.ts
@@ -19,7 +19,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Ahriman"}),
               ],
               '_modelList': [
-                "Ahriman (Inferno Bolt Pistol, Black Staff of Ahriman, Frag grenade, Krak grenade)"
+                "Ahriman (Inferno Bolt Pistol, Black Staff of Ahriman, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
@@ -39,7 +39,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Exalted Sorcerer"}),
               ],
               '_modelList': [
-                "Exalted Sorcerer (Inferno Bolt Pistol, Force stave, Frag grenade, Krak grenade)"
+                "Exalted Sorcerer (Inferno Bolt Pistol, Force stave, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
@@ -122,7 +122,7 @@ describe("Create40kRoster", function() {
               ],
               '_modelList': [
                 "Scarab Occult Sorcerer (Inferno Combi-bolter, Force stave)",
-                "4x Terminator (Inferno Combi-bolter, Power sword)"
+                "4x Terminator (Inferno Combi-bolter, Powersword)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Inferno Combi-bolter"}),
@@ -142,7 +142,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Heldrake"}),
               ],
               '_modelList': [
-                "Heldrake (Hades autocannon, Heldrake claws)"
+                "Heldrake (Hades Autocannon, Heldrake claws)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Hades autocannon"}),

--- a/spec/NecronJune20212Spec.ts
+++ b/spec/NecronJune20212Spec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Necron June 2021 2.ros", function() {
-    const doc = readRosterFile('test/Necron June 2021 2.ros');
+  it("loads test/Necron June 2021 2.ros", async function() {
+    const doc = await readZippedRosterFile('test/Necron June 2021 2.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(
@@ -78,7 +78,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Cryptothrall"}),
               ],
               '_modelList': [
-                "Cryptothralls (2x Scouring Eye, 2x Scythed Limbs)"
+                "2x Cryptothrall (Scouring Eye, Scythed Limbs)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Scouring Eye"}),

--- a/spec/NecronJune20212Spec.ts
+++ b/spec/NecronJune20212Spec.ts
@@ -39,7 +39,6 @@ describe("Create40kRoster", function() {
               '_name': "Skorpekh Destroyers",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Skorpekh Destroyer"}),
-                jasmine.objectContaining({'_name': "Skorpekh Destroyer"}),
               ],
               '_modelList': [
                 "Skorpekh Destroyer (Reap-Blade) (Hyperphase Reap-Blade)",

--- a/spec/NecronJune20212Spec.ts
+++ b/spec/NecronJune20212Spec.ts
@@ -8,11 +8,24 @@ describe("Create40kRoster", function() {
 
     expect(roster).toEqual(
       jasmine.objectContaining({
-        '_powerLevel': 25,
-        '_points': 500,
+        '_powerLevel': 31,
+        '_points': 620,
         '_commandPoints': 3,
         '_forces': [
           jasmine.objectContaining({'_units': [
+            jasmine.objectContaining({
+              '_name': "Chronomancer",
+              '_modelStats': [
+                jasmine.objectContaining({'_name': "Chronomancer"}),
+              ],
+              '_modelList': [
+                "Chronomancer (Aeonstave, Chronotendrils)"
+              ],
+              '_weapons': [
+                jasmine.objectContaining({'_name': "Aeonstave (Shooting)"}),
+                jasmine.objectContaining({'_name': "Aeonstave (Melee)"}),
+                jasmine.objectContaining({'_name': "Chronotendrils"}),
+              ]}),
             jasmine.objectContaining({
               '_name': "Royal Warden",
               '_modelStats': [
@@ -58,6 +71,18 @@ describe("Create40kRoster", function() {
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Feeder Mandibles"}),
+              ]}),
+            jasmine.objectContaining({
+              '_name': "Bound Creation",
+              '_modelStats': [
+                jasmine.objectContaining({'_name': "Cryptothrall"}),
+              ],
+              '_modelList': [
+                "Cryptothralls (2x Scouring Eye, 2x Scythed Limbs)"
+              ],
+              '_weapons': [
+                jasmine.objectContaining({'_name': "Scouring Eye"}),
+                jasmine.objectContaining({'_name': "Scythed Limbs"}),
               ]}),
           ]}),
         ]}));

--- a/spec/NecronTestSpec.ts
+++ b/spec/NecronTestSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Necron Test.ros", function() {
-    const doc = readRosterFile('test/Necron Test.ros');
+  it("loads test/Necron Test.ros", async function() {
+    const doc = await readZippedRosterFile('test/Necron Test.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/SalamanderstestSpec.ts
+++ b/spec/SalamanderstestSpec.ts
@@ -8,8 +8,8 @@ describe("Create40kRoster", function() {
 
     expect(roster).toEqual(
       jasmine.objectContaining({
-        '_powerLevel': 24,
-        '_points': 475,
+        '_powerLevel': 32,
+        '_points': 625,
         '_commandPoints': 6,
         '_forces': [
           jasmine.objectContaining({'_units': [
@@ -80,6 +80,27 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Heavy flamer"}),
                 jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
                 jasmine.objectContaining({'_name': "Redemptor Fist"}),
+              ]}),
+            jasmine.objectContaining({
+              '_name': "Devastator Squad",
+              '_modelStats': [
+                jasmine.objectContaining({'_name': "Devastator Marine"}),
+                jasmine.objectContaining({'_name': "Devastator Marine Sergeant"}),
+              ],
+              '_modelList': [
+                "Devastator Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Devastator Marine w/Heavy Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
+                "Devastator Marine w/Heavy Weapon (Bolt pistol, Multi-melta, Frag & Krak grenades)",
+                "Devastator Marine w/Heavy Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
+                "Devastator Marine w/Heavy Weapon (Bolt pistol, Multi-melta, Frag & Krak grenades)"
+              ],
+              '_weapons': [
+                jasmine.objectContaining({'_name': "Bolt pistol"}),
+                jasmine.objectContaining({'_name': "Boltgun"}),
+                jasmine.objectContaining({'_name': "Heavy bolter"}),
+                jasmine.objectContaining({'_name': "Multi-melta"}),
+                jasmine.objectContaining({'_name': "Frag grenades"}),
+                jasmine.objectContaining({'_name': "Krak grenades"}),
               ]}),
           ]}),
         ]}));

--- a/spec/SalamanderstestSpec.ts
+++ b/spec/SalamanderstestSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Salamanders test.ros", function() {
-    const doc = readRosterFile('test/Salamanders test.ros');
+  it("loads test/Salamanders test.ros", async function() {
+    const doc = await readZippedRosterFile('test/Salamanders test.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(
@@ -89,10 +89,8 @@ describe("Create40kRoster", function() {
               ],
               '_modelList': [
                 "Devastator Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Devastator Marine w/Heavy Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
-                "Devastator Marine w/Heavy Weapon (Bolt pistol, Multi-melta, Frag & Krak grenades)",
-                "Devastator Marine w/Heavy Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
-                "Devastator Marine w/Heavy Weapon (Bolt pistol, Multi-melta, Frag & Krak grenades)"
+                "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
+                "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Multi-melta, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),

--- a/spec/SalamanderstestSpec.ts
+++ b/spec/SalamanderstestSpec.ts
@@ -19,7 +19,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Captain"}),
               ],
               '_modelList': [
-                "Captain (Bolt pistol, Boltgun, Meltagun, Relic blade, Frag grenades, Krak grenades, Forge Master, Obsidian Aquila)"
+                "Captain (Bolt pistol, Combi-melta, Relic blade, Frag & Krak grenades, Forge Master, Obsidian Aquila)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -36,9 +36,9 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
               ],
               '_modelList': [
-                "3x Space Marine (Bolt pistol, Boltgun, Frag grenades, Krak grenades)",
-                "Space Marine Sergeant (Bolt pistol, Boltgun, Frag grenades, Krak grenades)",
-                "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag grenades, Krak grenades)"
+                "3x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -54,9 +54,9 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
               ],
               '_modelList': [
-                "3x Space Marine (Bolt pistol, Boltgun, Frag grenades, Krak grenades)",
-                "Space Marine Sergeant (Bolt pistol, 2x Boltgun, Flamer, Frag grenades, Krak grenades)",
-                "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag grenades, Krak grenades)"
+                "3x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                "Space Marine Sergeant (Bolt pistol, 2x Boltgun, Combi-flamer, Frag & Krak grenades)",
+                "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -73,7 +73,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Redemptor Dreadnought [3] (1-3 wounds remaining)"}),
               ],
               '_modelList': [
-                "Redemptor Dreadnought (Fragstorm Grenade Launcher, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
+                "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),

--- a/spec/Tau_TestSpec.ts
+++ b/spec/Tau_TestSpec.ts
@@ -54,7 +54,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Fire Warrior"}),
               ],
               '_modelList': [
-                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenade)"
+                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Pulse rifle"}),
@@ -66,7 +66,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Fire Warrior"}),
               ],
               '_modelList': [
-                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenade)"
+                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Pulse rifle"}),
@@ -78,7 +78,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Fire Warrior"}),
               ],
               '_modelList': [
-                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenade)"
+                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Pulse rifle"}),
@@ -90,7 +90,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Kroot Shaper"}),
               ],
               '_modelList': [
-                "Kroot Shaper (Kroot rifle (shooting), Kroot rifle (melee), Ritual blade)"
+                "Kroot Shaper (Kroot rifle, Ritual blade)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Kroot rifle (shooting)"}),
@@ -104,7 +104,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre"}),
               ],
               '_modelList': [
-                "XV95 Ghostkeel Battlesuit (Flamer, Fusion collider)"
+                "XV95 Ghostkeel Battlesuit (2x Flamer, Fusion collider)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Flamer"}),
@@ -121,7 +121,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter"}),
               ],
               '_modelList': [
-                "AX3 Razorshark Strike Fighter (Burst cannon, Quad ion turret (Overcharge), Quad ion turret (Standard), 2x Seeker missile)"
+                "AX3 Razorshark Strike Fighter (Burst cannon, Quad ion turret, 2x Seeker missile)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Burst cannon"}),
@@ -183,7 +183,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Darkstrider"}),
               ],
               '_modelList': [
-                "Darkstrider (Markerlight, Pulse carbine, Photon grenade)"
+                "Darkstrider (Markerlight, Pulse carbine, Photon grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Markerlight"}),
@@ -196,7 +196,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Fire Warrior"}),
               ],
               '_modelList': [
-                "5x Fire Warrior (Pulse blaster (1 Close range), Pulse blaster (2 Medium range), Pulse blaster (3 Long range), Photon grenade)"
+                "5x Fire Warrior (Pulse blaster, Photon grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Pulse blaster (1 Close range)"}),
@@ -210,7 +210,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Kroot"}),
               ],
               '_modelList': [
-                "10x Kroot (Kroot rifle (shooting), Kroot rifle (melee))"
+                "10x Kroot (Kroot rifle)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Kroot rifle (shooting)"}),
@@ -222,7 +222,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Fire Warrior"}),
               ],
               '_modelList': [
-                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenade)"
+                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Pulse rifle"}),
@@ -256,7 +256,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Dahyak Grekh"}),
               ],
               '_modelList': [
-                "Dahyak Grekh (Kroot pistol, Kroot rifle (shooting), Kroot rifle (melee))"
+                "Dahyak Grekh (Kroot pistol, Kroot rifle)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Kroot pistol"}),
@@ -269,7 +269,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
               ],
               '_modelList': [
-                "XV104 Riptide Battlesuit (Heavy burst cannon, Smart missile system)"
+                "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy burst cannon"}),
@@ -286,7 +286,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
               ],
               '_modelList': [
-                "XV104 Riptide Battlesuit (Heavy burst cannon, Smart missile system)"
+                "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy burst cannon"}),
@@ -303,7 +303,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
               ],
               '_modelList': [
-                "XV104 Riptide Battlesuit (Heavy burst cannon, Smart missile system)"
+                "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Heavy burst cannon"}),

--- a/spec/Tau_TestSpec.ts
+++ b/spec/Tau_TestSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Tau_Test.ros", function() {
-    const doc = readRosterFile('test/Tau_Test.ros');
+  it("loads test/Tau_Test.ros", async function() {
+    const doc = await readZippedRosterFile('test/Tau_Test.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/TyranidsTestSpec.ts
+++ b/spec/TyranidsTestSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Tyranids Test.ros", function() {
-    const doc = readRosterFile('test/Tyranids Test.ros');
+  it("loads test/Tyranids Test.ros", async function() {
+    const doc = await readZippedRosterFile('test/Tyranids Test.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/TyranidsTestSpec.ts
+++ b/spec/TyranidsTestSpec.ts
@@ -19,7 +19,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Abominant"}),
               ],
               '_modelList': [
-                "Abominant (Familiar Claws, Power Sledgehammer, Rending Claw(s))"
+                "Abominant (Familiar Claws, Power Sledgehammer, Rending Claw)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Familiar Claws"}),
@@ -50,13 +50,12 @@ describe("Create40kRoster", function() {
               '_name': "Acolyte Hybrids",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Acolyte Hybrid"}),
-                jasmine.objectContaining({'_name': "Acolyte Hybrid"}),
                 jasmine.objectContaining({'_name': "Acolyte Leader"}),
               ],
               '_modelList': [
-                "4x Acolyte Hybrid (Autopistol, Cultist Knife, Rending Claw(s), Blasting Charge)",
-                "Acolyte Hybrid (Heavy Weapon) (Autopistol, Heavy Rock Saw, Blasting Charge)",
-                "Acolyte Leader (Autopistol, Cultist Knife, Rending Claw(s), Blasting Charge)"
+                "4x Acolyte Hybrid (Autopistol, Cultist Knife, Rending Claw, Blasting Charges)",
+                "Acolyte Hybrid (Heavy Weapon) (Autopistol, Heavy Rock Saw, Blasting Charges)",
+                "Acolyte Leader (Autopistol, Cultist Knife, Rending Claw, Blasting Charges)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Autopistol"}),
@@ -69,19 +68,16 @@ describe("Create40kRoster", function() {
               '_name': "Brood Brothers Infantry Squad",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Brood Brother"}),
-                jasmine.objectContaining({'_name': "Brood Brother"}),
-                jasmine.objectContaining({'_name': "Brood Brother"}),
-                jasmine.objectContaining({'_name': "Brood Brother"}),
                 jasmine.objectContaining({'_name': "Brood Brothers Leader"}),
                 jasmine.objectContaining({'_name': "Brood Brothers Weapons Team"}),
               ],
               '_modelList': [
-                "9x Brood Brother (Lasgun, Frag Grenade)",
-                "Brood Brother (Flamer) (Flamer, Frag Grenade)",
-                "Brood Brother (Grenade) (Grenade Launcher (Frag), Grenade Launcher (Krak), Frag Grenade)",
-                "Brood Brother (Vox-caster) (Lasgun, Frag Grenade, Cult Vox-caster)",
-                "Brood Brothers Leader (Laspistol, Chainsword, Frag Grenade)",
-                "Brood Brothers Weapons Team (Lascannon, Lasgun, Frag Grenade)"
+                "9x Brood Brother (Lasgun, Frag Grenades)",
+                "Brood Brother (Flamer) (Flamer, Frag Grenades)",
+                "Brood Brother (Grenade) (Grenade Launcher, Frag Grenades)",
+                "Brood Brother (Vox-caster) (Lasgun, Frag Grenades, Cult Vox-caster)",
+                "Brood Brothers Leader (Laspistol, Chainsword, Frag Grenades)",
+                "Brood Brothers Weapons Team (Lascannon, Lasgun, Frag Grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Flamer"}),
@@ -97,19 +93,15 @@ describe("Create40kRoster", function() {
               '_name': "Neophyte Hybrids",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Neophyte Hybrid"}),
-                jasmine.objectContaining({'_name': "Neophyte Hybrid"}),
-                jasmine.objectContaining({'_name': "Neophyte Hybrid"}),
-                jasmine.objectContaining({'_name': "Neophyte Hybrid"}),
-                jasmine.objectContaining({'_name': "Neophyte Hybrid"}),
                 jasmine.objectContaining({'_name': "Neophyte Leader"}),
               ],
               '_modelList': [
-                "9x Neophyte Hybrid (Autogun, Autopistol, Blasting Charge)",
-                "Neophyte Hybrid (Flamer) (Autopistol, Flamer, Blasting Charge)",
-                "Neophyte Hybrid (Lasgun) (Autopistol, Lasgun, Blasting Charge)",
-                "Neophyte Hybrid (Mining) (Autopistol, Mining Laser, Blasting Charge)",
-                "Neophyte Hybrid (Shotgun) (Autopistol, Shotgun, Blasting Charge)",
-                "Neophyte Leader (Autogun, Autopistol, Blasting Charge)"
+                "9x Neophyte Hybrid (Autogun, Autopistol, Blasting Charges)",
+                "Neophyte Hybrid (Flamer) (Autopistol, Flamer, Blasting Charges)",
+                "Neophyte Hybrid (Lasgun) (Autopistol, Lasgun, Blasting Charges)",
+                "Neophyte Hybrid (Mining) (Autopistol, Mining Laser, Blasting Charges)",
+                "Neophyte Hybrid (Shotgun) (Autopistol, Shotgun, Blasting Charges)",
+                "Neophyte Leader (Autogun, Autopistol, Blasting Charges)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Autogun"}),
@@ -124,13 +116,11 @@ describe("Create40kRoster", function() {
               '_name': "Atalan Jackals",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Atalan Jackal"}),
-                jasmine.objectContaining({'_name': "Atalan Jackal"}),
-                jasmine.objectContaining({'_name': "Atalan Jackal"}),
                 jasmine.objectContaining({'_name': "Atalan Leader"}),
               ],
               '_modelList': [
-                "3x Atalan Jackal (Autopistol, Blasting Charge)",
-                "Atalan Leader (Autopistol, Power Pick, Blasting Charge, Demolition Charge)"
+                "3x Atalan Jackal (Autopistol, Blasting Charges)",
+                "Atalan Leader (Autopistol, Power Pick, Blasting Charges, Demolition Charge)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Autopistol"}),
@@ -144,7 +134,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Cult Leman Russ"}),
               ],
               '_modelList': [
-                "Cult Leman Russ (Battle Cannon, Heavy bolter, Heavy flamer, Heavy stubber, Hunter-killer missile)"
+                "Cult Leman Russ (Battle Cannon, Heavy Bolter, 2x Heavy Flamer, Heavy Stubber, Hunter-killer Missile)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Battle Cannon"}),
@@ -164,7 +154,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Goliath Rockgrinder"}),
               ],
               '_modelList': [
-                "Goliath Rockgrinder (Cache of Demolition Charges, Heavy Mining Laser, Heavy stubber, Drilldozer Blade)"
+                "Goliath Rockgrinder (Cache of Demolition Charges, Heavy Mining Laser, Heavy Stubber, Drilldozer Blade)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Cache of Demolition Charges"}),
@@ -203,7 +193,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Hive Tyrant"}),
               ],
               '_modelList': [
-                "Hive Tyrant (Monstrous Scything Talons, Prehensile Pincer Tail)"
+                "Hive Tyrant (2x Monstrous Scything Talons, Prehensile Pincer Tail)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Monstrous Scything Talons"}),
@@ -243,10 +233,6 @@ describe("Create40kRoster", function() {
               '_name': "Tyranid Warriors",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Tyranid Warrior"}),
-                jasmine.objectContaining({'_name': "Tyranid Warrior"}),
-                jasmine.objectContaining({'_name': "Tyranid Warrior"}),
-                jasmine.objectContaining({'_name': "Tyranid Warrior"}),
-                jasmine.objectContaining({'_name': "Tyranid Warrior"}),
               ],
               '_modelList': [
                 "Tyranid Warrior (Devourer, Boneswords)",
@@ -267,7 +253,6 @@ describe("Create40kRoster", function() {
               '_name': "Hive Guard",
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Hive Guard"}),
-                jasmine.objectContaining({'_name': "Hive Guard"}),
               ],
               '_modelList': [
                 "3x Hive Guard (Impaler) (Impaler Cannon)",
@@ -283,7 +268,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Carnifex"}),
               ],
               '_modelList': [
-                "Carnifex (Monstrous Scything Talons)"
+                "Carnifex (2x Monstrous Scything Talons)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Monstrous Scything Talons"}),
@@ -311,7 +296,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Toxicrene"}),
               ],
               '_modelList': [
-                "Toxicrene (Choking Spores, Massive Toxic Lashes)"
+                "Toxicrene (Chocking Spores, Massive Toxic Lashes)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Choking Spores"}),

--- a/spec/XenosTestSpec.ts
+++ b/spec/XenosTestSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/Xenos Test.ros", function() {
-    const doc = readRosterFile('test/Xenos Test.ros');
+  it("loads test/Xenos Test.ros", async function() {
+    const doc = await readZippedRosterFile('test/Xenos Test.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/XenosTestSpec.ts
+++ b/spec/XenosTestSpec.ts
@@ -20,7 +20,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Grot Oiler"}),
               ],
               '_modelList': [
-                "Grot Oiler (Slugga, Choppa, Stikkbomb)"
+                "Grot Oiler (Slugga, Choppa, Stikkbombs)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Slugga"}),
@@ -51,7 +51,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Ork Boy"}),
               ],
               '_modelList': [
-                "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbomb)"
+                "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Slugga"}),
@@ -63,12 +63,11 @@ describe("Create40kRoster", function() {
               '_modelStats': [
                 jasmine.objectContaining({'_name': "Boss Nob"}),
                 jasmine.objectContaining({'_name': "Ork Boy"}),
-                jasmine.objectContaining({'_name': "Ork Boy"}),
               ],
               '_modelList': [
-                "Boss Nob (Slugga, Choppa, Stikkbomb)",
-                "2x Ork Boy W/ Shoota (Shoota, Stikkbomb)",
-                "8x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbomb)"
+                "Boss Nob (Slugga, Choppa, Stikkbombs)",
+                "2x Ork Boy W/ Shoota (Shoota, Stikkbombs)",
+                "8x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Shoota"}),
@@ -83,8 +82,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Ork Boy"}),
               ],
               '_modelList': [
-                "Boss Nob (Slugga, Choppa, Stikkbomb)",
-                "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbomb)"
+                "Boss Nob (Slugga, Choppa, Stikkbombs)",
+                "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Slugga"}),

--- a/spec/helpers/40kRosterExpectation.ts
+++ b/spec/helpers/40kRosterExpectation.ts
@@ -1,20 +1,20 @@
-import { readRosterFile } from './readRosterFile';
+import { readZippedRosterFile } from './readRosterFile';
 import { BaseNotes, Create40kRoster, Force, Unit } from "../../src/roster40k";
 
-export function getRosterExpectation(filename: string): string {
-  const doc = readRosterFile(filename);
+export async function getRosterExpectation(filename: string): Promise<string> {
+  const doc = await readZippedRosterFile(filename);
   const roster = Create40kRoster(doc);
 
   if (!roster) {
     throw new Error(`ERROR: Roster '${filename}' did not parse.`);
   }
 
-  return `import { readRosterFile } from './helpers/readRosterFile';
+  return `import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads ${filename}", function() {
-    const doc = readRosterFile('${filename}');
+  it("loads ${filename}", async function() {
+    const doc = await readZippedRosterFile('${filename}');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/helpers/print40kRosterExpectation.ts
+++ b/spec/helpers/print40kRosterExpectation.ts
@@ -15,9 +15,7 @@ function main(args: string[]) {
     return;
   }
 
-  for (const filename of args.slice(2)) {
-    console.log(getRosterExpectation(filename));
-  }
+  Promise.all(args.slice(2).map(getRosterExpectation));
 }
 
 main(process.argv);

--- a/spec/helpers/printRosterStructure.ts
+++ b/spec/helpers/printRosterStructure.ts
@@ -5,7 +5,7 @@
  *   $ ts-node spec/helpers/printRosterStructure.ts 'path/to/file'
  */
 
-import { readRosterFile } from './readRosterFile';
+import { readZippedRosterFile } from './readRosterFile';
 
 /**
  * Visits an Element node and its children, outputting useful bits to console.
@@ -41,15 +41,14 @@ function visit(el: Element, indent = 0): void {
 
 }
 
-function main(args: string[]) {
+async function main(args: string[]) {
   if (args.length !== 3) {
     console.error(`ERROR: Expected one CLI argument; got ${args.length}: ${args.join(' ')}`);
     return;
   }
   const filename = args[2];
-  const doc = readRosterFile(filename);
+  const doc = await readZippedRosterFile(filename);
   visit(doc.documentElement);
-
 }
 
 main(process.argv);

--- a/spec/helpers/readRosterFile.ts
+++ b/spec/helpers/readRosterFile.ts
@@ -1,8 +1,25 @@
 import fs from "fs";
 import {JSDOM} from 'jsdom';
+import JSZip from "jszip";
 
 export function readRosterFile(filename: string): Document {
-  // For now, this doesn't support zipped files. Add later if needed.
-  const xmldata: string = fs.readFileSync(filename).toString();
+  const xmldata: string = fs.readFileSync(filename, 'binary');
   return new JSDOM(xmldata, { contentType: "text/xml" }).window.document;
+}
+
+export async function readZippedRosterFile(filename: string): Promise<Document> {
+  const contents: string = fs.readFileSync(filename, 'binary');
+  const xmldata = await unzip(contents);
+  return new JSDOM(xmldata, { contentType: "text/xml" }).window.document;
+}
+
+async function unzip(contents: string): Promise<string> {
+  if (contents.charAt(0) !== 'P') {
+    return contents;
+  } else {
+    const jszip = new JSZip();
+    const zip = await jszip.loadAsync(contents);
+    return zip.file(/[^/]+\.ros/)[0].async('string'); // Get roster files that are in the root
+  }
+
 }

--- a/spec/helpers/write40kRosterExpectation.ts
+++ b/spec/helpers/write40kRosterExpectation.ts
@@ -8,7 +8,7 @@
 import fs from "fs";
 import { getRosterExpectation } from "./40kRosterExpectation";
 
-function writeRosterExpectations(filename: string) {
+async function writeRosterExpectations(filename: string) {
   const filenameMatch = filename.match('([^/]+)\.rosz?$');
   if (!filenameMatch) {
     console.error(`ERROR: Unexpected input filename doesn't match regex: ${filename}`);
@@ -16,7 +16,7 @@ function writeRosterExpectations(filename: string) {
   }
   const outputFilename = `spec/${filenameMatch[1].replace(/\s/g, '')}Spec.ts`;
 
-  const output = getRosterExpectation(filename);
+  const output = await getRosterExpectation(filename);
 
   fs.writeFile(outputFilename, output, function (err) {
     if (err) return console.log(err);
@@ -30,9 +30,7 @@ function main(args: string[]) {
     return;
   }
 
-  for (const filename of args.slice(2)) {
-    writeRosterExpectations(filename);
-  }
+  Promise.all(args.slice(2).map(writeRosterExpectations));
 }
 
 main(process.argv);

--- a/spec/rosterSpec.ts
+++ b/spec/rosterSpec.ts
@@ -1,9 +1,9 @@
-import { readRosterFile } from './helpers/readRosterFile';
+import { readZippedRosterFile } from './helpers/readRosterFile';
 import { Create40kRoster } from "../src/roster40k";
 
 describe("Create40kRoster", function() {
-  it("loads test/roster.ros", function() {
-    const doc = readRosterFile('test/roster.ros');
+  it("loads test/roster.ros", async function() {
+    const doc = await readZippedRosterFile('test/roster.ros');
     const roster = Create40kRoster(doc);
 
     expect(roster).toEqual(

--- a/spec/rosterSpec.ts
+++ b/spec/rosterSpec.ts
@@ -19,7 +19,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Captain in Phobos Armour"}),
               ],
               '_modelList': [
-                "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag grenade, Krak grenade, Camo cloak, Frontline Commander)"
+                "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Frontline Commander)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -34,7 +34,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Emperor's Champion"}),
               ],
               '_modelList': [
-                "The Emperor's Champion (Bolt pistol, Black Sword, Frag grenade, Krak grenade)"
+                "The Emperor's Champion (Bolt pistol, Black Sword, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -49,8 +49,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Sword Brother"}),
               ],
               '_modelList': [
-                "4x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag grenade, Krak grenade)",
-                "Sword Brother (Bolt pistol, Power fist, Frag grenade, Krak grenade)"
+                "4x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
+                "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -66,8 +66,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Infiltrator Sergeant"}),
               ],
               '_modelList': [
-                "4x Infilltrator (Bolt pistol, Marksman bolt carbine, Frag grenade, Krak grenade)",
-                "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag grenade, Krak grenade)"
+                "4x Infilltrator (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)",
+                "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -82,8 +82,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
               ],
               '_modelList': [
-                "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag grenade, Krak grenade)",
-                "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag grenade, Krak grenade)"
+                "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag & Krak grenades)",
+                "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -99,8 +99,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
               ],
               '_modelList': [
-                "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag grenade, Krak grenade)",
-                "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag grenade, Krak grenade)"
+                "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag & Krak grenades)",
+                "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -116,7 +116,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Veteran Sergeant (Jump Pack)"}),
               ],
               '_modelList': [
-                "Vanguard Veteran Squad (Grav-pistol, Relic blade, 4x Thunder hammer, 5x Frag grenade, 5x Krak grenade)"
+                "Vanguard Veteran Squad (Grav-pistol, Relic blade, 4x Thunder hammer, 5x Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Grav-pistol"}),
@@ -132,7 +132,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
               ],
               '_modelList': [
-                "Assault Squad (2x Bolt pistol, 3x Plasma pistol, Standard, 3x Plasma pistol, Supercharge, 4x Chainsword, 4x Frag grenade, 4x Krak grenade)"
+                "Assault Squad (2x Bolt pistol, 3x Plasma pistol, 4x Chainsword, 4x Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -149,8 +149,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Suppressor Sergeant"}),
               ],
               '_modelList': [
-                "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag grenade, Krak grenade, Grav-chute)",
-                "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag grenade, Krak grenade, Grav-chute)"
+                "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)",
+                "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Accelerator autocannon"}),
@@ -165,8 +165,8 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
               ],
               '_modelList': [
-                "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Bolt sniper rifle - Executioner round, Bolt sniper rifle - Hyperfrag round, Bolt sniper rifle - Mortis round, Frag grenade, Krak grenade)",
-                "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Bolt sniper rifle - Executioner round, Bolt sniper rifle - Hyperfrag round, Bolt sniper rifle - Mortis round, Frag grenade, Krak grenade)"
+                "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades)",
+                "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -218,7 +218,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Chaplain Grimaldus"}),
               ],
               '_modelList': [
-                "Chaplain Grimaldus (Plasma pistol, Standard, Plasma pistol, Supercharge, Artificer Crozius, Frag grenade, Krak grenade)"
+                "Chaplain Grimaldus (Plasma pistol, Artificer Crozius, Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Plasma pistol, Standard"}),
@@ -248,7 +248,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Redemptor Dreadnought"}),
               ],
               '_modelList': [
-                "Redemptor Dreadnought (Fragstorm Grenade Launcher, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
+                "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
@@ -268,7 +268,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
               ],
               '_modelList': [
-                "Devastator Squad (7x Bolt pistol, Boltgun, 4x Grav-cannon and grav-amp, Chainsword, 6x Frag grenade, 6x Krak grenade)"
+                "Devastator Squad (7x Bolt pistol, Boltgun, 4x Grav-cannon and grav-amp, Chainsword, 6x Frag & Krak grenades)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -317,7 +317,7 @@ describe("Create40kRoster", function() {
                 jasmine.objectContaining({'_name': "Impulsor"}),
               ],
               '_modelList': [
-                "Impulsor (Ironhail Heavy Stubber, Ironhail Sytalon Array, Storm bolter)"
+                "Impulsor (Ironhail Heavy Stubber, Ironhail Skytalon Array, 2x Storm Bolters)"
               ],
               '_weapons': [
                 jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),

--- a/src/roster40k.ts
+++ b/src/roster40k.ts
@@ -39,6 +39,8 @@ export class BaseNotes {
 }
 
 export class Weapon extends BaseNotes {
+    _selectionName: string = "";
+
     _count: number = 0;
     _range: string = "Melee";
     _type: string = "Melee";
@@ -179,20 +181,11 @@ export class Model extends BaseNotes {
             const seenWeapons: string[] = [];
             const weaponNames: string[] = [];
             for (const weapon of this._weapons) {
-                let wName = weapon.name();
-                // Dedupe "Stikka (Shooting)" and "Stikka (Melee)" into "Stikka".
-                const dedupeMatch = wName.match(/(.*) \((Shooting|Melee)\)$/);
-                if (dedupeMatch) {
-                    wName = dedupeMatch[1];
-                    if (seenWeapons.includes(wName)) {
-                        continue;
-                    } else {
-                        seenWeapons.push(wName);
-                    }
-                }
+                let wName = weapon._selectionName || weapon.name();
                 if (weapon._count > 1) {
                     wName = `${weapon._count}x ${wName}`;
                 }
+                if (weaponNames.includes(wName)) continue;
                 weaponNames.push(wName);
             }
             weaponNames.push(...this._upgrades);
@@ -305,6 +298,15 @@ export class Unit extends BaseNotes {
 
         for (let model of this._models) {
             model.normalize();
+        }
+
+        for (let i = 0; i < (this._modelStats.length - 1); i++) {
+            const model = this._modelStats[i];
+
+            if (model.equal(this._modelStats[i+1])) {
+                this._modelStats.splice(i+1, 1);
+                i--;
+            }
         }
 
         this._modelList = this._models.map(model => (model._count > 1 ? `${model._count}x ` : '') + model.nameAndGear());
@@ -855,6 +857,13 @@ function ParseWeaponProfile(profile: Element): Weapon {
                 }
             }
         }
+    }
+    // Keep track of the weapon's parent selection for its name, unless the
+    // weapon is directly under the unit's profile.
+    const selection = profile.parentElement?.parentElement;
+    const selectionName = selection?.getAttribute('name');
+    if (selection?.getAttribute('type') === 'upgrade' && selectionName) {
+        weapon._selectionName = selectionName;
     }
     return weapon;
 }

--- a/src/roster40k.ts
+++ b/src/roster40k.ts
@@ -279,7 +279,7 @@ export class Unit extends BaseNotes {
 
     normalize(): void {
         // Sort force units by role and name
-        this._models.sort(CompareObj);
+        this._models.sort(CompareModel);
         this._modelStats.sort(CompareObj);
 
         for (let model of this._models) {
@@ -674,9 +674,13 @@ function ParseUnit(root: Element, is40k: boolean): Unit | null {
     } else {
         const immediateSelections = GetImmediateSelections(root);
         for (const selection of immediateSelections) {
-            if (selection.getAttribute('type') === 'model' || selection.querySelector('profile[typeName="Unit"]')) {
+            if (selection.getAttribute('type') === 'model' || HasImmediateProfileWithTypeName(selection, 'Unit')) {
                 modelSelections.push(selection);
             }
+        }
+        // Some units are under a root selection with type="upgrade".
+        if (modelSelections.length === 0) {
+            modelSelections.push(...Array.from(root.querySelectorAll('selection[type="model"]')));
         }
         // Some single-model units have type="unit" or type="upgrade".
         if (modelSelections.length === 0 && HasImmediateProfileWithTypeName(root, 'Unit')) {
@@ -954,6 +958,10 @@ function ParsePsykerProfile(profile: Element): Psyker {
 
 function CompareObj(a: { _name: string; }, b: { _name: string; }): number {
     return Compare(a._name, b._name);
+}
+
+function CompareModel(a: Model, b: Model): number {
+    return Compare(a._name, b._name) || Compare(a.nameAndGear(), b.nameAndGear());
 }
 
 export function CompareWeapon(a: Weapon, b: Weapon): number {

--- a/test/Necron June 2021 2.ros
+++ b/test/Necron June 2021 2.ros
@@ -1,99 +1,101 @@
 <?xml version="1.0" encoding="utf-8"?>
-<roster xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" battleScribeVersion="2.03" gameSystemId="28ec-711c-d87f-3aeb" gameSystemName="Warhammer 40,000 9th Edition" gameSystemRevision="191" id="d6cd-29e7-927d-4269" name="Necron June 2021 2" xmlns="http://www.battlescribe.net/schema/rosterSchema">
+<roster xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" battleScribeVersion="2.03" gameSystemId="28ec-711c-d87f-3aeb" gameSystemName="Warhammer 40,000 9th Edition" gameSystemRevision="196" id="d6cd-29e7-927d-4269" name="Necron June 2021 2" xmlns="http://www.battlescribe.net/schema/rosterSchema">
   <costs>
-    <cost typeId="e356-c769-5920-6e14" value="25" name=" PL" />
-    <cost typeId="points" value="500" name="pts" />
+    <cost typeId="e356-c769-5920-6e14" value="31" name=" PL" />
+    <cost typeId="points" value="620" name="pts" />
     <cost typeId="2d3b-b544-ad49-fb75" value="3" name="CP" />
   </costs>
   <costLimits>
     <costLimit typeId="points" value="500" name="pts" />
   </costLimits>
   <forces>
-    <force catalogueId="61c6-c8c5-a304-ff5f" catalogueName="Necrons" catalogueRevision="92" entryId="a0c7-2a71-bae0-215d" id="108b-0ede-09c4-e7ba" name="Patrol Detachment 0CP">
+    <force catalogueId="61c6-c8c5-a304-ff5f" catalogueName="Necrons" catalogueRevision="95" entryId="a0c7-2a71-bae0-215d" id="108b-0ede-09c4-e7ba" name="Patrol Detachment 0CP">
       <publications>
-        <publication id="ecea-8b62-fefb-9f8e" name="Psychic Awakening VII: Engine War" />
-        <publication id="977a-446b-737a-b571" name="Chapter Approved 2021" />
+        <publication id="e056-7215-247f-0a20" name="War Zone Octarius, Book 1: Rising Tide" />
         <publication id="28ec-711c-pubN73170" name="Chapter Approved 2017" />
         <publication id="2ec0-6d53-e36b-9895" name="Chapter Approved 2018" />
-        <publication id="28ec-711c-pubN99666" name="Index: Chaos" />
         <publication id="c9fe-4431-b76d-267a" name="Psychic Awakening VIII: War of the Spider" />
-        <publication id="ce40-ec9e-21e2-2e42" name="Warhammer Quest: Blackstone Fortress" />
         <publication id="5093-9448-d8cc-5327" name="Psychic Awakening II: Faith and Fury" />
-        <publication id="5c2d-db9f-58ca-e7b2" name="Psychic Awakening IV: Ritual of the Damned" />
-        <publication id="28ec-711c-pubN118139" name="Index: Xenos 2" />
         <publication id="28ec-711c-pubN98266" name="Imperium Nihilus: Vigilus Defiant" />
-        <publication id="0865-ee21-d1f1-ed38" name="War Zone Charadon, Act I: The Book of Rust" />
-        <publication id="61c6-c8c5-pubN65537" name="Codex: Necrons" />
         <publication id="28ec-711c-pubN78977" name="Index: Imperium 1" />
-        <publication id="28ec-711c-pubN77581" name="Index: Imperium 2" />
-        <publication id="28ec-711c-pubN76527" name="Index: Xenos 1" />
         <publication id="5b08-09e5-a80a-fd67" name="Psychic Awakening I: Phoenix Rising" />
+        <publication id="28ec-711c-pubN76527" name="Index: Xenos 1" />
         <publication id="b652-8bab-1453-da20" name="Warhammer Legends" />
         <publication id="7573-8d1b-acdf-2de8" name="Imperial Armour: Compendium" />
-        <publication id="f000-7b0c-01bf-7630" name="Psychic Awakening III: Blood of Baal" />
-        <publication id="4593-a2f0-546a-d6f2" name="Psychic Awakening V: The Greater Good" />
         <publication id="85df-1155-c986-4d71" name="Psychic Awakening IX: Pariah" />
+        <publication id="b854-bcb5-5746-e0d3" name="War Zone Charadon, Act II: The Book of Fire" />
+        <publication id="ecea-8b62-fefb-9f8e" name="Psychic Awakening VII: Engine War" />
+        <publication id="977a-446b-737a-b571" name="Chapter Approved 2021" />
+        <publication id="28ec-711c-pubN99666" name="Index: Chaos" />
+        <publication id="ce40-ec9e-21e2-2e42" name="Warhammer Quest: Blackstone Fortress" />
+        <publication id="5c2d-db9f-58ca-e7b2" name="Psychic Awakening IV: Ritual of the Damned" />
+        <publication id="28ec-711c-pubN118139" name="Index: Xenos 2" />
+        <publication id="0865-ee21-d1f1-ed38" name="War Zone Charadon, Act I: The Book of Rust" />
+        <publication id="61c6-c8c5-pubN65537" name="Codex: Necrons" />
+        <publication id="28ec-711c-pubN77581" name="Index: Imperium 2" />
+        <publication id="f000-7b0c-01bf-7630" name="Psychic Awakening III: Blood of Baal" />
         <publication id="28ec-711c-pubN72690" name="Warhammer 40,000 Core Book" />
+        <publication id="4593-a2f0-546a-d6f2" name="Psychic Awakening V: The Greater Good" />
         <publication id="52c4-39c0-ae97-d4dc" name="Psychic Awakening VI: Saga of the Beast" />
       </publications>
       <categories>
-        <category primary="false" entryId="(No Category)" id="aec4-901d-ee85-edcb" name="Uncategorised">
+        <category primary="false" entryId="(No Category)" id="e91b-15d9-b19b-7cf6" name="Uncategorised">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="fcff-0f21-93e6-1ddc" id="33a1-21b7-e4c3-779b" name="Configuration">
+        <category primary="false" entryId="fcff-0f21-93e6-1ddc" id="8bea-eb1d-c90a-d6b0" name="Configuration">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="c845-c72c-6afe-3fc2" id="68ea-4364-7bc9-7444" name="Stratagems">
+        <category primary="false" entryId="c845-c72c-6afe-3fc2" id="2724-a9eb-2a67-9ebe" name="Stratagems">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" id="4ebf-8440-f3ff-a9cf" name="No Force Org Slot">
+        <category primary="false" entryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" id="f782-dbd7-9e28-8b29" name="No Force Org Slot">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="0f35-2c34-ba6a-8105" id="3910-821c-e8a6-4d60" name="Agents of the Imperium">
+        <category primary="false" entryId="0f35-2c34-ba6a-8105" id="6814-16b8-85f7-2d30" name="Agents of the Imperium">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" id="7aea-55b5-df63-2907" name="HQ">
+        <category primary="false" entryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" id="4725-9f20-8587-297c" name="HQ">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="51ed-8f93-f81f-d9e4" name="Troops">
+        <category primary="false" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="aa11-c945-7584-7ef6" name="Troops">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" id="0503-8ca8-8189-ca31" name="Elites">
+        <category primary="false" entryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" id="eb8d-7970-2e8a-f056" name="Elites">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="c274d0b0-5866-44bc-9810-91c136ae7438" id="dffd-a661-9924-e84a" name="Fast Attack">
+        <category primary="false" entryId="c274d0b0-5866-44bc-9810-91c136ae7438" id="8047-242f-54b8-5b84" name="Fast Attack">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" id="7229-3d1e-1890-0658" name="Heavy Support">
+        <category primary="false" entryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" id="4e97-04dc-8c0e-597e" name="Heavy Support">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="e888-1504-aa61-95ff" id="6e51-6f78-a511-a0bd" name="Flyer">
+        <category primary="false" entryId="e888-1504-aa61-95ff" id="bced-da64-7907-4fd9" name="Flyer">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="1b66-3f5f-6705-079a" id="18d1-697a-466d-53b9" name="Dedicated Transport">
+        <category primary="false" entryId="1b66-3f5f-6705-079a" id="d055-c753-f394-b498" name="Dedicated Transport">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="8d86-9490-0f7d-a5b5" id="136c-163a-ff48-0d6a" name="Relic Elites">
+        <category primary="false" entryId="8d86-9490-0f7d-a5b5" id="d6b2-26e4-9b9a-941a" name="Relic Elites">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="6c4c-a416-b8cb-c380" id="efe3-f972-478c-8025" name="Relic Heavy Support">
+        <category primary="false" entryId="6c4c-a416-b8cb-c380" id="280a-7da4-00f4-0170" name="Relic Heavy Support">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="655f-e142-dfa9-11a4" id="88a5-76eb-5149-2d0c" name="Relic HQ">
+        <category primary="false" entryId="655f-e142-dfa9-11a4" id="4cd5-9d2b-3487-7200" name="Relic HQ">
           <rules />
           <profiles />
         </category>
@@ -107,7 +109,7 @@
             <cost typeId="points" value="0" name="pts" />
           </costs>
           <categories>
-            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="1c7a-900c-be1b-af58" name="Configuration">
+            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="5645-0034-c8d4-f9fe" name="Configuration">
               <rules />
               <profiles />
             </category>
@@ -173,7 +175,7 @@
             <cost typeId="points" value="0" name="pts" />
           </costs>
           <categories>
-            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="5cda-7625-f6c7-90ce" name="Configuration">
+            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="1e34-2029-6b9a-e239" name="Configuration">
               <rules />
               <profiles />
             </category>
@@ -189,27 +191,27 @@
             <cost typeId="points" value="75" name="pts" />
           </costs>
           <categories>
-            <category primary="false" entryId="ef18-746a-369f-43a4" id="0972-0917-cd9b-c207" name="Character">
+            <category primary="false" entryId="ef18-746a-369f-43a4" id="0112-3bbe-9f9e-6cf8" name="Character">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="0be0-e1d1-1fb5-c137" name="Faction: &lt;Dynasty&gt;">
+            <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="c897-b688-3ec6-6ada" name="Faction: &lt;Dynasty&gt;">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="876e-ea78-1fdf-f250" id="ceea-d7b2-85a4-0f63" name="Faction: Necrons">
+            <category primary="false" entryId="876e-ea78-1fdf-f250" id="41e6-1b27-6c2b-f7b6" name="Faction: Necrons">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="21f3-a4e5-af57-36b7" name="Infantry">
+            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="90cc-52e5-cc3b-82fb" name="Infantry">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="a6d1-ecdc-5d74-f1d7" id="e47e-ab24-bce3-ec6b" name="Royal Warden">
+            <category primary="false" entryId="a6d1-ecdc-5d74-f1d7" id="4ce4-b08f-33b1-bd72" name="Royal Warden">
               <rules />
               <profiles />
             </category>
-            <category primary="true" entryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" id="93a6-d09e-7bd0-6ea7" name="HQ">
+            <category primary="true" entryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" id="ccd7-cc9c-cd1c-d6fa" name="HQ">
               <rules />
               <profiles />
             </category>
@@ -246,7 +248,7 @@
                 <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
               </costs>
               <categories>
-                <category primary="false" entryId="ae09-117e-a6fa-316b" id="7928-5ed5-0cc1-a6f4" name="Warlord">
+                <category primary="false" entryId="ae09-117e-a6fa-316b" id="d35f-ae3b-60fd-0e6f" name="Warlord">
                   <rules />
                   <profiles />
                 </category>
@@ -351,27 +353,27 @@ If the battle lasts for more than five battle rounds, then until the end of the 
             <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
           </costs>
           <categories>
-            <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="b49a-0c2d-ac5e-c19e" name="Faction: &lt;Dynasty&gt;">
+            <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="6232-5815-c07c-7cf6" name="Faction: &lt;Dynasty&gt;">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="876e-ea78-1fdf-f250" id="836e-41af-bd5b-ac73" name="Faction: Necrons">
+            <category primary="false" entryId="876e-ea78-1fdf-f250" id="4516-b06c-46b1-7f40" name="Faction: Necrons">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="9630-8e33-6ab3-e678" name="Infantry">
+            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="5fc9-6c50-badd-ab29" name="Infantry">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="08f1-d244-eb44-7e01" id="c6c3-5b81-0935-c0c3" name="Core">
+            <category primary="false" entryId="08f1-d244-eb44-7e01" id="f7b4-20cd-d924-351c" name="Core">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="c9db-16b2-d65f-708b" id="b119-452a-d154-8215" name="Necron Warriors">
+            <category primary="false" entryId="c9db-16b2-d65f-708b" id="999f-d351-8c6a-3fd2" name="Necron Warriors">
               <rules />
               <profiles />
             </category>
-            <category primary="true" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="0919-9baa-3761-5b1e" name="Troops">
+            <category primary="true" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="827a-8835-c608-a609" name="Troops">
               <rules />
               <profiles />
             </category>
@@ -480,31 +482,31 @@ If the battle lasts for more than five battle rounds, then until the end of the 
             <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
           </costs>
           <categories>
-            <category primary="false" entryId="c276-12d8-a188-16a2" id="8219-cdab-e1c5-3a65" name="Canoptek Scarab Swarms">
+            <category primary="false" entryId="c276-12d8-a188-16a2" id="a276-faf5-2346-f78b" name="Canoptek Scarab Swarms">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="accb-e3d8-1193-10cc" id="a37d-312e-69ab-38cc" name="Faction: Canoptek">
+            <category primary="false" entryId="accb-e3d8-1193-10cc" id="06da-2d11-170a-9679" name="Faction: Canoptek">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="c13f-1fd8-207d-ed08" name="Faction: &lt;Dynasty&gt;">
+            <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="fcbb-3f6b-da82-6c19" name="Faction: &lt;Dynasty&gt;">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="876e-ea78-1fdf-f250" id="15d4-7fd3-30b0-b4b2" name="Faction: Necrons">
+            <category primary="false" entryId="876e-ea78-1fdf-f250" id="3d3a-1f86-3075-c78b" name="Faction: Necrons">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="3117-16d8-fcef-4f56" id="439d-1edd-bb25-2849" name="Fly">
+            <category primary="false" entryId="3117-16d8-fcef-4f56" id="6041-632b-a3e0-8ac6" name="Fly">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="7a53-eedc-8dbb-8505" id="08c6-84fd-efc0-2b36" name="Swarm">
+            <category primary="false" entryId="7a53-eedc-8dbb-8505" id="35f2-295a-267a-dd48" name="Swarm">
               <rules />
               <profiles />
             </category>
-            <category primary="true" entryId="c274d0b0-5866-44bc-9810-91c136ae7438" id="cfac-7833-7859-bde5" name="Fast Attack">
+            <category primary="true" entryId="c274d0b0-5866-44bc-9810-91c136ae7438" id="5ec6-b3ca-0e88-9e66" name="Fast Attack">
               <rules />
               <profiles />
             </category>
@@ -605,7 +607,7 @@ If the battle lasts for more than five battle rounds, then until the end of the 
             <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
           </costs>
           <categories>
-            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="c1cd-88cf-0cee-3c75" name="Configuration">
+            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="f786-607c-5f5e-d557" name="Configuration">
               <rules />
               <profiles />
             </category>
@@ -633,27 +635,27 @@ If the battle lasts for more than five battle rounds, then until the end of the 
             <cost typeId="points" value="0" name="pts" />
           </costs>
           <categories>
-            <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="c1c6-eef9-5f31-9475" name="Faction: &lt;Dynasty&gt;">
+            <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="b673-b35b-ed6f-5910" name="Faction: &lt;Dynasty&gt;">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="876e-ea78-1fdf-f250" id="fcfa-6381-2e9c-3661" name="Faction: Necrons">
+            <category primary="false" entryId="876e-ea78-1fdf-f250" id="c2fa-bd1f-67fe-f832" name="Faction: Necrons">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="0ad7-1f84-c52c-ff8c" id="cc8c-a0ff-bd2d-cfbe" name="Faction: Destroyer Cult">
+            <category primary="false" entryId="0ad7-1f84-c52c-ff8c" id="8ef2-a254-2f80-07da" name="Faction: Destroyer Cult">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="3256-e432-c454-d771" name="Infantry">
+            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="4861-9c58-6351-915d" name="Infantry">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="d4f8-74ea-220c-41f6" id="1735-2c5a-b14e-8341" name="Skorpekh Destroyers">
+            <category primary="false" entryId="d4f8-74ea-220c-41f6" id="32a6-122b-f2cf-6106" name="Skorpekh Destroyers">
               <rules />
               <profiles />
             </category>
-            <category primary="true" entryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" id="6709-93ab-5ccf-2a16" name="Elites">
+            <category primary="true" entryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" id="7ef3-68ab-28d0-2526" name="Elites">
               <rules />
               <profiles />
             </category>
@@ -807,6 +809,345 @@ You then reduce the number of dice in that pool by a number equal to the Wounds 
             </profile>
           </profiles>
         </selection>
+        <selection number="1" type="model" entryId="a11c-4537-cb77-91bf::e4d8-225b-cae1-1f20" publicationId="61c6-c8c5-pubN65537" id="934d-19c5-e8c8-eb2a" name="Chronomancer">
+          <costs>
+            <cost typeId="e356-c769-5920-6e14" value="4" name=" PL" />
+            <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+            <cost typeId="points" value="80" name="pts" />
+          </costs>
+          <categories>
+            <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="932c-bd11-fb64-2b72" name="Faction: &lt;Dynasty&gt;">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="876e-ea78-1fdf-f250" id="2556-ba0f-f8f2-4cdc" name="Faction: Necrons">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="0d3c-3b8d-7d5f-5441" name="Infantry">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="3117-16d8-fcef-4f56" id="27e4-1f32-aa22-dc9e" name="Fly">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="ef18-746a-369f-43a4" id="6d7b-d4db-998d-e609" name="Character">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="092a-b667-f7aa-1b33" id="4c0c-6a22-53dd-782a" name="Cryptek">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="6e3f-0788-7a38-de1f" id="2ce9-9349-02a9-bb01" name="Chronomancer">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="true" entryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" id="8934-caa1-c8db-463a" name="HQ">
+              <rules />
+              <profiles />
+            </category>
+          </categories>
+          <selections>
+            <selection number="1" type="upgrade" entryId="a11c-4537-cb77-91bf::410b-ecd0-4cdf-f7f3::db55-b9bd-d72e-eefc" publicationId="61c6-c8c5-pubN65537" id="1064-3518-afe1-4299" name="Chronotendrils">
+              <costs>
+                <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                <cost typeId="points" value="0" name="pts" />
+              </costs>
+              <categories />
+              <selections />
+              <rules />
+              <profiles>
+                <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" publicationId="61c6-c8c5-pubN65537" page="113" id="a11c-4537-cb77-91bf::410b-ecd0-4cdf-f7f3::15bc-396e-a9d1-7d37" name="Chronotendrils">
+                  <characteristics>
+                    <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">Melee</characteristic>
+                    <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Melee</characteristic>
+                    <characteristic typeId="59b1-319e-ec13-d466" name="S">User</characteristic>
+                    <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                    <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                    <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Each time the bearer fights, it makes 3 additional attacks with this weapon.</characteristic>
+                  </characteristics>
+                  <modifiers />
+                  <modifierGroups />
+                </profile>
+              </profiles>
+            </selection>
+            <selection number="1" type="upgrade" entryId="a11c-4537-cb77-91bf::60c6-6932-eb51-02b2::282a-36bc-148d-ffa2" entryGroupId="a11c-4537-cb77-91bf::14c4-9cf7-c1c8-0d0d" publicationId="61c6-c8c5-pubN65537" id="d12e-a615-e3c7-6c27" name="Aeonstave">
+              <costs>
+                <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                <cost typeId="points" value="0" name="pts" />
+                <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+              </costs>
+              <categories />
+              <selections />
+              <rules />
+              <profiles>
+                <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" publicationId="61c6-c8c5-pubN65537" page="112" id="a11c-4537-cb77-91bf::60c6-6932-eb51-02b2::3618-0120-d606-9d58" name="Aeonstave (Shooting)">
+                  <characteristics>
+                    <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">18"</characteristic>
+                    <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Assault D3</characteristic>
+                    <characteristic typeId="59b1-319e-ec13-d466" name="S">5</characteristic>
+                    <characteristic typeId="75aa-a838-b675-6484" name="AP">-2</characteristic>
+                    <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                    <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Blast. Each time an attack is made with this weapon, invulnerable saving throws cannot be taken against this attack.</characteristic>
+                  </characteristics>
+                  <modifiers />
+                  <modifierGroups />
+                </profile>
+                <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" publicationId="61c6-c8c5-pubN65537" page="114" id="a11c-4537-cb77-91bf::60c6-6932-eb51-02b2::4ea8-9270-99d3-5a5a" name="Aeonstave (Melee)">
+                  <characteristics>
+                    <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">Melee</characteristic>
+                    <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Melee</characteristic>
+                    <characteristic typeId="59b1-319e-ec13-d466" name="S">User</characteristic>
+                    <characteristic typeId="75aa-a838-b675-6484" name="AP">-2</characteristic>
+                    <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                    <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Each time an attack is made with this weapon, invulnerable saving throws cannot be taken against this attack.</characteristic>
+                  </characteristics>
+                  <modifiers />
+                  <modifierGroups />
+                </profile>
+              </profiles>
+            </selection>
+          </selections>
+          <rules>
+            <rule hidden="false" publicationId="61c6-c8c5-pubN65537" page="81" id="a11c-4537-cb77-91bf::3afb-2f21-2e34-5c90::aa07-b2de-6de0-3dd9" name="Command Protocols">
+              <description>If every unit from your army (excluding DYNASTIC AGENT, C'TAN SHARD and UNALIGNED units) is from the same dynasty, and you select a NOBLE model to be your WARLORD, this unit is eligible to benefit from this ability and the following rules apply.  
+
+After both sides have deployed, but before you have determined who will have the first turn, you must assign a different one of the command protocols to each of the first five battle rounds, and note this down secretly on your army roster.
+
+At the start of each battle round, if any NOBLE units from your army are on the battlefield, the command protocol that you assigned to that battle round becomes active for your army until the end of that battle round. Each command protocol is made up of two directives. When a command protocol becomes active for your army, reveal it to your opponent and select one of its directives. Until the assigned command protocol stops being active, while a unit that is eligible to benefit from this ability is within 6" of a friendly NECRONS CHARACTER model (excluding C'TAN SHARD models), that unit benefits from the selected directive.
+
+If the battle lasts for more than five battle rounds, then until the end of the battle, whichever command protocol was active in the fifth battle round remains active.</description>
+              <modifiers />
+              <modifierGroups />
+            </rule>
+            <rule hidden="false" publicationId="61c6-c8c5-pubN65537" page="80" id="a11c-4537-cb77-91bf::0447-1f6f-b70b-a85c::601f-ad02-3e1f-fcc4" name="Living Metal">
+              <description>At the start of your Command phase, each model in this unit regains 1 lost wound.</description>
+              <modifiers />
+              <modifierGroups />
+            </rule>
+          </rules>
+          <profiles>
+            <profile typeId="800f-21d0-4387-c943" typeName="Unit" hidden="false" publicationId="61c6-c8c5-pubN65537" page="91" id="a11c-4537-cb77-91bf::dbea-3744-5de9-a1bf" name="Chronomancer">
+              <characteristics>
+                <characteristic typeId="0bdf-a96e-9e38-7779" name="M">8"</characteristic>
+                <characteristic typeId="e7f0-1278-0250-df0c" name="WS">3+</characteristic>
+                <characteristic typeId="381b-eb28-74c3-df5f" name="BS">3+</characteristic>
+                <characteristic typeId="2218-aa3c-265f-2939" name="S">4</characteristic>
+                <characteristic typeId="9c9f-9774-a358-3a39" name="T">4</characteristic>
+                <characteristic typeId="f330-5e6e-4110-0978" name="W">4</characteristic>
+                <characteristic typeId="13fc-b29b-31f2-ab9f" name="A">1</characteristic>
+                <characteristic typeId="00ca-f8b8-876d-b705" name="Ld">10</characteristic>
+                <characteristic typeId="c0df-df94-abd7-e8d3" name="Save">4+</characteristic>
+              </characteristics>
+              <modifiers />
+              <modifierGroups />
+            </profile>
+            <profile typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities" hidden="false" publicationId="61c6-c8c5-pubN65537" page="91" id="a11c-4537-cb77-91bf::51ad-8b92-5f8d-8a07::ac3d-4098-0cb7-a49c" name="Chronometron">
+              <characteristics>
+                <characteristic typeId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description">In your Command phase, you can select one friendly &lt;DYNASTY&gt; unit within 9" of this model. Until the start of your next Command phase, you can re-roll charge rolls made for that unit and models in that unit have a 5+ invulnerable save.</characteristic>
+              </characteristics>
+              <modifiers />
+              <modifierGroups />
+            </profile>
+            <profile typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities" hidden="false" publicationId="61c6-c8c5-pubN65537" page="91" id="a11c-4537-cb77-91bf::c2ec-2f6d-6784-51df::90a7-d474-48a8-47b8" name="Timesplinter Mantle">
+              <characteristics>
+                <characteristic typeId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description">This model has a 4+ invulnerable save.</characteristic>
+              </characteristics>
+              <modifiers />
+              <modifierGroups />
+            </profile>
+            <profile typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities" hidden="false" publicationId="61c6-c8c5-pubN65537" page="90" id="a11c-4537-cb77-91bf::ac3d-cdf5-cfb9-f3c8::8e55-3c95-511b-0bbf" name="Dynastic Advisors">
+              <characteristics>
+                <characteristic typeId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description">If your army is Battle-forged, then for each CRYPTEK unit (excluding DYNASTIC AGENTS units) included in a Detachment that also contains at least one NOBLE unit, a second CRYPTEK unit (excluding DYNASTIC AGENTS units) can be included in that Detachment without taking up an additional Battlefield Role slot. [These are located in the Cryptek Selection under Dynastic Advisor]</characteristic>
+              </characteristics>
+              <modifiers />
+              <modifierGroups />
+            </profile>
+          </profiles>
+        </selection>
+        <selection number="1" type="upgrade" entryId="7d63-4d79-a732-8f78::e963-9438-acc3-2d9d" publicationId="61c6-c8c5-pubN65537" id="8059-5101-6ffc-3b50" name="Bound Creation">
+          <costs>
+            <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+            <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+            <cost typeId="points" value="0" name="pts" />
+          </costs>
+          <categories>
+            <category primary="true" entryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" id="d5dc-96de-fdc8-d832" name="No Force Org Slot">
+              <rules />
+              <profiles />
+            </category>
+          </categories>
+          <selections>
+            <selection number="1" type="unit" entryId="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::2368-8890-e2af-f17f" publicationId="61c6-c8c5-pubN65537" id="c620-0c13-c86f-ef45" name="Cryptothralls">
+              <costs>
+                <cost typeId="e356-c769-5920-6e14" value="2" name=" PL" />
+                <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                <cost typeId="points" value="40" name="pts" />
+              </costs>
+              <categories>
+                <category primary="false" entryId="4aa1-01cf-3c41-def2" id="38f4-fa08-00db-b1f6" name="Cryptothralls">
+                  <rules />
+                  <profiles />
+                </category>
+                <category primary="false" entryId="6a37-4c9f-a323-a8f2" id="68a0-38b2-a47a-046e" name="Faction: &lt;Dynasty&gt;">
+                  <rules />
+                  <profiles />
+                </category>
+                <category primary="false" entryId="accb-e3d8-1193-10cc" id="6053-3611-7040-a403" name="Faction: Canoptek">
+                  <rules />
+                  <profiles />
+                </category>
+                <category primary="false" entryId="876e-ea78-1fdf-f250" id="9f50-b23f-4ac4-57c7" name="Faction: Necrons">
+                  <rules />
+                  <profiles />
+                </category>
+                <category primary="false" entryId="3d52-fccf-10c0-3fae" id="ab42-6826-6682-5754" name="Infantry">
+                  <rules />
+                  <profiles />
+                </category>
+              </categories>
+              <selections>
+                <selection number="2" type="model" entryId="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::c780-b589-de84-7cef::e2b0-3354-c78f-297a" publicationId="61c6-c8c5-pubN65537" id="3a88-09cf-e3db-fcf3" name="Cryptothrall">
+                  <costs>
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                    <cost typeId="points" value="0" name="pts" />
+                  </costs>
+                  <categories />
+                  <selections>
+                    <selection number="2" type="upgrade" entryId="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::c780-b589-de84-7cef::6832-923e-32f9-797e::6792-2ab2-13eb-e964" publicationId="61c6-c8c5-pubN65537" id="0907-4a24-ca6f-01ec" name="Scythed Limbs">
+                      <costs>
+                        <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                        <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                        <cost typeId="points" value="0" name="pts" />
+                      </costs>
+                      <categories />
+                      <selections />
+                      <rules />
+                      <profiles>
+                        <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" publicationId="61c6-c8c5-pubN65537" page="115" id="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::c780-b589-de84-7cef::6832-923e-32f9-797e::b726-cc10-3e63-606e" name="Scythed Limbs">
+                          <characteristics>
+                            <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">Melee</characteristic>
+                            <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Melee</characteristic>
+                            <characteristic typeId="59b1-319e-ec13-d466" name="S">User</characteristic>
+                            <characteristic typeId="75aa-a838-b675-6484" name="AP">-1</characteristic>
+                            <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                            <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                          </characteristics>
+                          <modifiers />
+                          <modifierGroups />
+                        </profile>
+                      </profiles>
+                    </selection>
+                    <selection number="2" type="upgrade" entryId="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::c780-b589-de84-7cef::5990-98c1-2733-f37d::8c8f-c403-7548-dbbb" publicationId="61c6-c8c5-pubN65537" id="b639-efcc-a188-1b6a" name="Scouring Eye">
+                      <costs>
+                        <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                        <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                        <cost typeId="points" value="0" name="pts" />
+                      </costs>
+                      <categories />
+                      <selections />
+                      <rules />
+                      <profiles>
+                        <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" publicationId="61c6-c8c5-pubN65537" page="112" id="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::c780-b589-de84-7cef::5990-98c1-2733-f37d::d0e5-1544-d626-af62" name="Scouring Eye">
+                          <characteristics>
+                            <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">12"</characteristic>
+                            <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Pistol 2</characteristic>
+                            <characteristic typeId="59b1-319e-ec13-d466" name="S">5</characteristic>
+                            <characteristic typeId="75aa-a838-b675-6484" name="AP">-2</characteristic>
+                            <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                            <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                          </characteristics>
+                          <modifiers />
+                          <modifierGroups />
+                        </profile>
+                      </profiles>
+                    </selection>
+                  </selections>
+                  <rules />
+                  <profiles>
+                    <profile typeId="800f-21d0-4387-c943" typeName="Unit" hidden="false" publicationId="61c6-c8c5-pubN65537" page="95" id="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::c780-b589-de84-7cef::6a87-1ec8-2cf3-e49b" name="Cryptothrall">
+                      <characteristics>
+                        <characteristic typeId="0bdf-a96e-9e38-7779" name="M">5"</characteristic>
+                        <characteristic typeId="e7f0-1278-0250-df0c" name="WS">4+</characteristic>
+                        <characteristic typeId="381b-eb28-74c3-df5f" name="BS">4+</characteristic>
+                        <characteristic typeId="2218-aa3c-265f-2939" name="S">5</characteristic>
+                        <characteristic typeId="9c9f-9774-a358-3a39" name="T">5</characteristic>
+                        <characteristic typeId="f330-5e6e-4110-0978" name="W">2</characteristic>
+                        <characteristic typeId="13fc-b29b-31f2-ab9f" name="A">3</characteristic>
+                        <characteristic typeId="00ca-f8b8-876d-b705" name="Ld">10</characteristic>
+                        <characteristic typeId="c0df-df94-abd7-e8d3" name="Save">3+</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+              </selections>
+              <rules>
+                <rule hidden="false" publicationId="61c6-c8c5-pubN65537" page="80" id="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::9b3c-a73e-9c13-eeea::601f-ad02-3e1f-fcc4" name="Living Metal">
+                  <description>At the start of your Command phase, each model in this unit regains 1 lost wound.</description>
+                  <modifiers />
+                  <modifierGroups />
+                </rule>
+                <rule hidden="false" publicationId="61c6-c8c5-pubN65537" page="80" id="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::dc71-7a2f-8b6b-f1ae::cba7-3427-625e-eb99" name="Reanimation Protocols">
+                  <description>Each time an enemy unit shoots or fights, after it makes its attacks, if any models in this unit were destroyed as a result of those attacks but this unit was not destroyed, this unit's reanimation protocols are enacted and those destroyed models begin to reassemble.
+
+Each time a unit's reanimation protocols are enacted, make Reanimation Protocol rolls for that unit by rolling a number of D6 equal to the combined Wounds characteristics of all the reassembling models. Each Reanimation Protocol roll of 5+ is put into a pool. A Reanimation Protocol roll can never be modified by more than -1 or +1.
+
+If the number of dice in that pool is greater than or equal to the Wounds characteristic of any of the reassembling models, select one of those models to be Reanimated. A Reanimated model:
+	-Is added back to its unit with its full wounds remaining.
+	-Can only set up within Engagement Range of enemy units that are already within Engagement Range of the Reanimated model's unit.
+	-Cannot, if it is your Charge phase, be set up closer to any enemy units that are targets of a charge declared by its unit this phase.
+	-No longer counts as having been destroyed for the purposes of Morale tests this turn.
+
+You then reduce the number of dice in that pool by a number equal to the Wounds characteristic of the Reanimated model and repeat this process until either there are no more reassembling models, or the number of dice remaining in the pool is less than the Wounds characteristic of any of the reassembling models. Any models that did not Reanimate fail to reassemble, and any dice remaining in the pool are discarded.</description>
+                  <modifiers />
+                  <modifierGroups />
+                </rule>
+                <rule hidden="false" publicationId="61c6-c8c5-pubN65537" page="81" id="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::dda2-651e-6a32-f110::aa07-b2de-6de0-3dd9" name="Command Protocols">
+                  <description>If every unit from your army (excluding DYNASTIC AGENT, C'TAN SHARD and UNALIGNED units) is from the same dynasty, and you select a NOBLE model to be your WARLORD, this unit is eligible to benefit from this ability and the following rules apply.  
+
+After both sides have deployed, but before you have determined who will have the first turn, you must assign a different one of the command protocols to each of the first five battle rounds, and note this down secretly on your army roster.
+
+At the start of each battle round, if any NOBLE units from your army are on the battlefield, the command protocol that you assigned to that battle round becomes active for your army until the end of that battle round. Each command protocol is made up of two directives. When a command protocol becomes active for your army, reveal it to your opponent and select one of its directives. Until the assigned command protocol stops being active, while a unit that is eligible to benefit from this ability is within 6" of a friendly NECRONS CHARACTER model (excluding C'TAN SHARD models), that unit benefits from the selected directive.
+
+If the battle lasts for more than five battle rounds, then until the end of the battle, whichever command protocol was active in the fifth battle round remains active.</description>
+                  <modifiers />
+                  <modifierGroups />
+                </rule>
+              </rules>
+              <profiles>
+                <profile typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities" hidden="false" publicationId="61c6-c8c5-pubN65537" page="95" id="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::82d3-a9a6-e07c-cbd0" name="Bound Creation">
+                  <characteristics>
+                    <characteristic typeId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description">If your army is Battle-forged, then for each CRYPTEK unit included in a Detachment, one CRYPTOTHRALLS unit can be included in that Detachment without taking up a Battlefield Role slot.</characteristic>
+                  </characteristics>
+                  <modifiers />
+                  <modifierGroups />
+                </profile>
+                <profile typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities" hidden="false" publicationId="61c6-c8c5-pubN65537" page="95" id="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::7428-83dd-47b5-2107" name="Protectors (Aura)">
+                  <characteristics>
+                    <characteristic typeId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description">While a friendly CRYPTEK unit is within 3" of this unit, enemy units cannot target that CRYPTEK unit with ranged weapons.</characteristic>
+                  </characteristics>
+                  <modifiers />
+                  <modifierGroups />
+                </profile>
+                <profile typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities" hidden="false" publicationId="61c6-c8c5-pubN65537" page="95" id="7d63-4d79-a732-8f78::17cf-1b22-6033-63c7::0306-fbc4-b7d4-dedc" name="Systematic Vigour">
+                  <characteristics>
+                    <characteristic typeId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description">While this unit is within 6" of any friendly CRYPTEK units, models in this unit have a Weapon Skill and Ballistic Skill of 3+ and an Attacks characteristic of 6.</characteristic>
+                  </characteristics>
+                  <modifiers />
+                  <modifierGroups />
+                </profile>
+              </profiles>
+            </selection>
+          </selections>
+          <rules />
+          <profiles />
+        </selection>
       </selections>
       <rules>
         <rule hidden="false" publicationId="61c6-c8c5-pubN65537" page="51" id="aafd-7344-f075-8a81" name="Dynastic Agents and Star Gods">
@@ -815,7 +1156,7 @@ You then reduce the number of dice in that pool by a number equal to the Wounds 
           <modifierGroups />
         </rule>
         <rule hidden="false" publicationId="61c6-c8c5-pubN65537" page="51" id="71d0-0ae0-afee-02fa" name="The Royal Court">
-          <description>When mustering your army, if it contains THE SILENT KING model, that model must be selected as your WARLORD. Otherwise, if your army contains a PHAERON model, that model must be selected as your WARLORD. Otherwise, if your army caontains an OVERLORD model, that model must be selected as your WARLORD. Otherwise, if your army contains a LORD model, that model must be selected as your WARLORD. If your army contains none of the listed models, select your WARLORD as normal.</description>
+          <description>When mustering your army, if it contains THE SILENT KING model, that model must be selected as your WARLORD. Otherwise, if your army contains a PHAERON model, that model must be selected as your WARLORD. Otherwise, if your army contains an OVERLORD model, that model must be selected as your WARLORD. Otherwise, if your army contains a LORD model, that model must be selected as your WARLORD. If your army contains none of the listed models, select your WARLORD as normal.</description>
           <modifiers />
           <modifierGroups />
         </rule>

--- a/test/Salamanders test.ros
+++ b/test/Salamanders test.ros
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<roster xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" battleScribeVersion="2.03" gameSystemId="28ec-711c-d87f-3aeb" gameSystemName="Warhammer 40,000 9th Edition" gameSystemRevision="195" id="59b6-67e6-4d67-941a" name="Salamanders test" xmlns="http://www.battlescribe.net/schema/rosterSchema">
+<roster xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" battleScribeVersion="2.03" gameSystemId="28ec-711c-d87f-3aeb" gameSystemName="Warhammer 40,000 9th Edition" gameSystemRevision="196" id="59b6-67e6-4d67-941a" name="Salamanders test" xmlns="http://www.battlescribe.net/schema/rosterSchema">
   <costs>
-    <cost typeId="e356-c769-5920-6e14" value="24" name=" PL" />
+    <cost typeId="e356-c769-5920-6e14" value="32" name=" PL" />
     <cost typeId="2d3b-b544-ad49-fb75" value="6" name="CP" />
-    <cost typeId="points" value="475" name="pts" />
+    <cost typeId="points" value="625" name="pts" />
   </costs>
   <costLimits />
   <forces>
@@ -41,63 +41,63 @@
         <publication id="52c4-39c0-ae97-d4dc" name="Psychic Awakening VI: Saga of the Beast" />
       </publications>
       <categories>
-        <category primary="false" entryId="(No Category)" id="47ab-3067-2c50-b9c4" name="Uncategorised">
+        <category primary="false" entryId="(No Category)" id="0404-d614-3d69-968d" name="Uncategorised">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="fcff-0f21-93e6-1ddc" id="31b0-2427-bc20-c7fb" name="Configuration">
+        <category primary="false" entryId="fcff-0f21-93e6-1ddc" id="c633-d0b5-cbb1-cd83" name="Configuration">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="c845-c72c-6afe-3fc2" id="b467-148d-ecbe-6c70" name="Stratagems">
+        <category primary="false" entryId="c845-c72c-6afe-3fc2" id="08fa-f82a-8e4b-6eb9" name="Stratagems">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" id="71fd-0afa-fd89-24a0" name="No Force Org Slot">
+        <category primary="false" entryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" id="9148-471b-b7af-7e47" name="No Force Org Slot">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="0f35-2c34-ba6a-8105" id="477f-7695-7e60-f909" name="Agents of the Imperium">
+        <category primary="false" entryId="0f35-2c34-ba6a-8105" id="7f51-58ce-0a31-5f0e" name="Agents of the Imperium">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" id="5cf7-8f6d-98bd-acd8" name="HQ">
+        <category primary="false" entryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" id="a197-c888-b725-f0e1" name="HQ">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="15df-58d8-126b-e02b" name="Troops">
+        <category primary="false" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="00f3-71b2-b13e-5ff6" name="Troops">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" id="d96b-d860-41a1-2514" name="Elites">
+        <category primary="false" entryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" id="cc30-c4cc-d68b-749c" name="Elites">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="c274d0b0-5866-44bc-9810-91c136ae7438" id="2eec-22de-9c69-ccdb" name="Fast Attack">
+        <category primary="false" entryId="c274d0b0-5866-44bc-9810-91c136ae7438" id="3010-271e-5cfd-49d3" name="Fast Attack">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" id="480f-f635-35ce-5dc0" name="Heavy Support">
+        <category primary="false" entryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" id="4b00-d811-9381-8dc7" name="Heavy Support">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="e888-1504-aa61-95ff" id="4c87-8210-17f0-b2d9" name="Flyer">
+        <category primary="false" entryId="e888-1504-aa61-95ff" id="0080-cb57-28eb-f646" name="Flyer">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="1b66-3f5f-6705-079a" id="1a11-4908-5dc3-14ba" name="Dedicated Transport">
+        <category primary="false" entryId="1b66-3f5f-6705-079a" id="bfc5-7ad7-cc5d-afd3" name="Dedicated Transport">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="8d86-9490-0f7d-a5b5" id="7be2-1c43-7f55-8be0" name="Relic Elites">
+        <category primary="false" entryId="8d86-9490-0f7d-a5b5" id="7900-dab2-9f72-ed7a" name="Relic Elites">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="6c4c-a416-b8cb-c380" id="6e9f-c995-db35-0258" name="Relic Heavy Support">
+        <category primary="false" entryId="6c4c-a416-b8cb-c380" id="ae4c-4d72-cd35-b52f" name="Relic Heavy Support">
           <rules />
           <profiles />
         </category>
-        <category primary="false" entryId="655f-e142-dfa9-11a4" id="ed7f-46b2-f435-d252" name="Relic HQ">
+        <category primary="false" entryId="655f-e142-dfa9-11a4" id="4d89-f20d-d036-c57d" name="Relic HQ">
           <rules />
           <profiles />
         </category>
@@ -111,11 +111,11 @@
             <cost typeId="points" value="0" name="pts" />
           </costs>
           <categories>
-            <category primary="false" entryId="0704-95d8-ed39-cb46" id="496e-df6a-1980-0cfc" name="PC: SA">
+            <category primary="false" entryId="0704-95d8-ed39-cb46" id="5ed6-2285-e40e-806f" name="PC: SA">
               <rules />
               <profiles />
             </category>
-            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="2f70-a25f-c1ff-0e2c" name="Configuration">
+            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="ba85-8fac-14eb-d77e" name="Configuration">
               <rules />
               <profiles />
             </category>
@@ -150,7 +150,7 @@
             <cost typeId="points" value="0" name="pts" />
           </costs>
           <categories>
-            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="a663-15c8-975f-641b" name="Configuration">
+            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="cd44-502f-6d14-19f7" name="Configuration">
               <rules />
               <profiles />
             </category>
@@ -166,7 +166,7 @@
             <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
           </costs>
           <categories>
-            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="38c8-777f-ef24-f17c" name="Configuration">
+            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="98ca-2590-a0df-c3de" name="Configuration">
               <rules />
               <profiles />
             </category>
@@ -194,7 +194,7 @@
             <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
           </costs>
           <categories>
-            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="3a0a-c6a3-dcf9-c95d" name="Configuration">
+            <category primary="true" entryId="fcff-0f21-93e6-1ddc" id="8077-f3b9-292a-e110" name="Configuration">
               <rules />
               <profiles />
             </category>
@@ -222,27 +222,27 @@
             <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
           </costs>
           <categories>
-            <category primary="false" entryId="c7b7-edbc-bc14-6238" id="cb02-1baf-72c4-dd2e" name="Faction: Adeptus Astartes">
+            <category primary="false" entryId="c7b7-edbc-bc14-6238" id="ea02-cebb-c177-c671" name="Faction: Adeptus Astartes">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="ef18-746a-369f-43a4" id="ad72-8bf5-615b-66e2" name="Character">
+            <category primary="false" entryId="ef18-746a-369f-43a4" id="7d97-0d63-ceca-407d" name="Character">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="84e2-9fa9-ebe6-1d18" id="5aca-b8f4-ce48-a05d" name="Faction: Imperium">
+            <category primary="false" entryId="84e2-9fa9-ebe6-1d18" id="a486-75a2-5a1b-0397" name="Faction: Imperium">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="0594-1c70-20b8-19c2" name="Infantry">
+            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="d5ff-b876-f474-1bfc" name="Infantry">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="8352-7f67-7e2b-3b4f" id="a7b4-b967-8cbd-8dcc" name="Captain">
+            <category primary="false" entryId="8352-7f67-7e2b-3b4f" id="1a6e-f79a-18ca-9ff5" name="Captain">
               <rules />
               <profiles />
             </category>
-            <category primary="true" entryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" id="3a4c-8aad-d283-33ff" name="HQ">
+            <category primary="true" entryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" id="a078-efc3-a2f6-5131" name="HQ">
               <rules />
               <profiles />
             </category>
@@ -381,7 +381,7 @@
                 <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
               </costs>
               <categories>
-                <category primary="false" entryId="ae09-117e-a6fa-316b" id="8033-06a9-f405-d8d3" name="Warlord">
+                <category primary="false" entryId="ae09-117e-a6fa-316b" id="3977-972a-ed23-e322" name="Warlord">
                   <rules />
                   <profiles />
                 </category>
@@ -475,31 +475,31 @@
             <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
           </costs>
           <categories>
-            <category primary="false" entryId="c7b7-edbc-bc14-6238" id="2b56-39ad-75d1-1d3b" name="Faction: Adeptus Astartes">
+            <category primary="false" entryId="c7b7-edbc-bc14-6238" id="cffa-daf1-e3c8-6085" name="Faction: Adeptus Astartes">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="84e2-9fa9-ebe6-1d18" id="186a-f5d2-3ab8-4d15" name="Faction: Imperium">
+            <category primary="false" entryId="84e2-9fa9-ebe6-1d18" id="90cb-efc1-12db-83c6" name="Faction: Imperium">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="8a81-be53-f561-c308" name="Infantry">
+            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="69c6-10aa-2ed5-be27" name="Infantry">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="184c-80ee-9ce9-c547" id="ac04-d855-56ba-16ea" name="Tactical Squad">
+            <category primary="false" entryId="184c-80ee-9ce9-c547" id="31ea-5142-47ab-02ff" name="Tactical Squad">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="08f1-d244-eb44-7e01" id="c4cf-394f-dc2b-5584" name="Core">
+            <category primary="false" entryId="08f1-d244-eb44-7e01" id="9e93-3be8-2b47-7f47" name="Core">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="9205-6ea5-f0b1-9131" id="403f-4cc3-1064-6a0e" name="Melta Bombs">
+            <category primary="false" entryId="9205-6ea5-f0b1-9131" id="6ff0-8823-26d7-4173" name="Melta Bombs">
               <rules />
               <profiles />
             </category>
-            <category primary="true" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="72f8-0c3f-ec56-2891" name="Troops">
+            <category primary="true" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="1587-4da2-2586-f84a" name="Troops">
               <rules />
               <profiles />
             </category>
@@ -846,31 +846,31 @@
             <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
           </costs>
           <categories>
-            <category primary="false" entryId="c7b7-edbc-bc14-6238" id="9a3a-f3bf-142c-618c" name="Faction: Adeptus Astartes">
+            <category primary="false" entryId="c7b7-edbc-bc14-6238" id="b098-c980-bb95-09d1" name="Faction: Adeptus Astartes">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="84e2-9fa9-ebe6-1d18" id="409e-fb1d-7ada-c15f" name="Faction: Imperium">
+            <category primary="false" entryId="84e2-9fa9-ebe6-1d18" id="7f38-df34-69b4-a9c7" name="Faction: Imperium">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="74d8-a197-617e-6bbd" name="Infantry">
+            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="3210-7d44-93fe-55c3" name="Infantry">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="184c-80ee-9ce9-c547" id="f285-f286-cd0e-a56e" name="Tactical Squad">
+            <category primary="false" entryId="184c-80ee-9ce9-c547" id="04e5-9ac9-b88d-11d9" name="Tactical Squad">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="08f1-d244-eb44-7e01" id="6b8e-9d25-2eb7-aae8" name="Core">
+            <category primary="false" entryId="08f1-d244-eb44-7e01" id="c930-4726-8725-6e67" name="Core">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="9205-6ea5-f0b1-9131" id="b662-1bc7-bfcf-5120" name="Melta Bombs">
+            <category primary="false" entryId="9205-6ea5-f0b1-9131" id="5ea6-2cdf-acd6-2bf9" name="Melta Bombs">
               <rules />
               <profiles />
             </category>
-            <category primary="true" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="727a-04da-c455-dd95" name="Troops">
+            <category primary="true" entryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" id="6180-635a-bf12-c7e6" name="Troops">
               <rules />
               <profiles />
             </category>
@@ -1259,31 +1259,31 @@
             <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
           </costs>
           <categories>
-            <category primary="false" entryId="c7b7-edbc-bc14-6238" id="2dc1-f853-b410-d37f" name="Faction: Adeptus Astartes">
+            <category primary="false" entryId="c7b7-edbc-bc14-6238" id="7e8a-ae35-70c5-4937" name="Faction: Adeptus Astartes">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="48e5-ceed-000a-a99a" id="b258-e225-0546-4bdb" name="Dreadnought">
+            <category primary="false" entryId="48e5-ceed-000a-a99a" id="d299-8b98-94ba-dc21" name="Dreadnought">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="84e2-9fa9-ebe6-1d18" id="a1a1-255c-b2d7-e612" name="Faction: Imperium">
+            <category primary="false" entryId="84e2-9fa9-ebe6-1d18" id="c3d7-31f8-ca52-a0c0" name="Faction: Imperium">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="4dbd-0c7e-ad6c-6d87" id="1f2a-8ea1-7475-e41b" name="Redemptor Dreadnought">
+            <category primary="false" entryId="4dbd-0c7e-ad6c-6d87" id="b7c4-d949-a77e-228d" name="Redemptor Dreadnought">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="c8fd-783f-3230-493e" id="10c8-f795-38d7-98d1" name="Vehicle">
+            <category primary="false" entryId="c8fd-783f-3230-493e" id="16ef-280d-d45c-3704" name="Vehicle">
               <rules />
               <profiles />
             </category>
-            <category primary="false" entryId="08f1-d244-eb44-7e01" id="68a4-51a8-a9ff-c6ea" name="Core">
+            <category primary="false" entryId="08f1-d244-eb44-7e01" id="f7f1-21da-9cb6-259e" name="Core">
               <rules />
               <profiles />
             </category>
-            <category primary="true" entryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" id="56fd-567d-203a-d39b" name="Elites">
+            <category primary="true" entryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" id="238a-8fb1-b201-7ff3" name="Elites">
               <rules />
               <profiles />
             </category>
@@ -1447,6 +1447,572 @@
             <profile typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities" hidden="false" id="b157-9336-1749-d9fe::2db7-95e7-3032-11c1::4857-c60f-691e-2145" name="Duty Eternal">
               <characteristics>
                 <characteristic typeId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description">Each time an attack is allocated to this model, subtract 1 from the Damage characteristic of that attack(to a minimum of 1)</characteristic>
+              </characteristics>
+              <modifiers />
+              <modifierGroups />
+            </profile>
+          </profiles>
+        </selection>
+        <selection number="1" type="unit" entryId="35c0-8dc5-d8cc-f847::a60f-c03f-ebe1-fa2c" id="7378-2d76-5942-b624" name="Devastator Squad">
+          <costs>
+            <cost typeId="e356-c769-5920-6e14" value="8" name=" PL" />
+            <cost typeId="points" value="0" name="pts" />
+            <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+          </costs>
+          <categories>
+            <category primary="false" entryId="c7b7-edbc-bc14-6238" id="9559-1a9d-1f4e-a068" name="Faction: Adeptus Astartes">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="6e07-61fe-30e8-e093" id="244a-8ad8-28a9-6f18" name="Devastator Squad">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="84e2-9fa9-ebe6-1d18" id="2d6c-29c2-0a8f-8150" name="Faction: Imperium">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="3d52-fccf-10c0-3fae" id="57d8-bf0e-548a-7e90" name="Infantry">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="false" entryId="08f1-d244-eb44-7e01" id="4adf-2a34-268e-a8fe" name="Core">
+              <rules />
+              <profiles />
+            </category>
+            <category primary="true" entryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" id="450c-14be-9abc-9425" name="Heavy Support">
+              <rules />
+              <profiles />
+            </category>
+          </categories>
+          <selections>
+            <selection number="1" type="model" entryId="35c0-8dc5-d8cc-f847::9dc7-4956-068a-e6cb" entryGroupId="35c0-8dc5-d8cc-f847::06f2-6ce7-3c52-a6bc" id="1223-1789-f06a-73d0" name="Devastator Marine Sergeant">
+              <costs>
+                <cost typeId="points" value="18" name="pts" />
+                <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+              </costs>
+              <categories />
+              <selections>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::a105-769d-2697-2f36::cddf-945e-1335-e681" id="5e8d-238b-c56d-04e4" name="Frag &amp; Krak grenades">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::a105-769d-2697-2f36::61a4-e2d3-522d-c838::fdd8-1a5f-5722-d6ee" name="Frag grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade D6</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">3</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Blast.</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::a105-769d-2697-2f36::b250-1f2e-4904-0eb4::3bf6-b4f7-6b2f-bb7b" name="Krak grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">6</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">-1</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">D3</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::c762-cc61-fe56-6b71::0334-f487-8229-0c1a" entryGroupId="35c0-8dc5-d8cc-f847::e38b-18c4-fd8a-c6a2" id="ad3d-0621-00c4-379e" name="Bolt pistol">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::c762-cc61-fe56-6b71::45bf-2847-b181-19e4::e6d5-677a-d8ed-f6a5" name="Bolt pistol">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">12"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Pistol 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">4</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::841e-0782-dd68-e928::b61f-a3c1-827d-c5b6" entryGroupId="35c0-8dc5-d8cc-f847::e38b-18c4-fd8a-c6a2" id="fa7e-0f16-dfd5-cc0d" name="Boltgun">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" page="" id="35c0-8dc5-d8cc-f847::841e-0782-dd68-e928::b122-fbba-f2e4-b4ff::3d4b-95ea-f860-dd22" name="Boltgun">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">24"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Rapid Fire 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">4</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+              </selections>
+              <rules />
+              <profiles />
+            </selection>
+            <selection number="1" type="model" entryId="35c0-8dc5-d8cc-f847::ccd7-6d4c-d706-5fe9" entryGroupId="35c0-8dc5-d8cc-f847::06f2-6ce7-3c52-a6bc" id="8bd0-d873-bb09-b566" name="Devastator Marine w/Heavy Weapon">
+              <costs>
+                <cost typeId="points" value="18" name="pts" />
+                <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+              </costs>
+              <categories />
+              <selections>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::8c98-ff8d-e199-fc77::37d3-7098-d596-9948" id="9b60-1e11-1442-5ef6" name="Bolt pistol">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::8c98-ff8d-e199-fc77::113b-392d-19be-cffa::e6d5-677a-d8ed-f6a5" name="Bolt pistol">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">12"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Pistol 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">4</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::cddf-945e-1335-e681" id="79ab-1bdf-9bcf-2a2a" name="Frag &amp; Krak grenades">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::61a4-e2d3-522d-c838::fdd8-1a5f-5722-d6ee" name="Frag grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade D6</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">3</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Blast.</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::b250-1f2e-4904-0eb4::3bf6-b4f7-6b2f-bb7b" name="Krak grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">6</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">-1</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">D3</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::abbe-1edb-7509-d4dd::05ab-e7cc-e856-c36f" entryGroupId="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::026f-f4dc-9e33-cd9d" id="06fa-b487-2d66-295f" name="Heavy bolter">
+                  <costs>
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                    <cost typeId="points" value="10" name="pts" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::abbe-1edb-7509-d4dd::f5ff-ee10-df57-d926::e2b0-b9f1-6c38-584c" name="Heavy bolter">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">36"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Heavy 3</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">5</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">-1</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">2</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+              </selections>
+              <rules />
+              <profiles />
+            </selection>
+            <selection number="1" type="model" entryId="35c0-8dc5-d8cc-f847::ccd7-6d4c-d706-5fe9" entryGroupId="35c0-8dc5-d8cc-f847::06f2-6ce7-3c52-a6bc" id="5e72-14b5-f1c1-04ff" name="Devastator Marine w/Heavy Weapon">
+              <costs>
+                <cost typeId="points" value="18" name="pts" />
+                <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+              </costs>
+              <categories />
+              <selections>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::8c98-ff8d-e199-fc77::37d3-7098-d596-9948" id="6e0c-84ca-5877-5ad8" name="Bolt pistol">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::8c98-ff8d-e199-fc77::113b-392d-19be-cffa::e6d5-677a-d8ed-f6a5" name="Bolt pistol">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">12"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Pistol 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">4</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::cddf-945e-1335-e681" id="a3fe-c4b4-ac6d-c2a5" name="Frag &amp; Krak grenades">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::61a4-e2d3-522d-c838::fdd8-1a5f-5722-d6ee" name="Frag grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade D6</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">3</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Blast.</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::b250-1f2e-4904-0eb4::3bf6-b4f7-6b2f-bb7b" name="Krak grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">6</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">-1</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">D3</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::8497-0034-668a-a40a::2b37-65ee-9443-b4ef" entryGroupId="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::026f-f4dc-9e33-cd9d" id="ee55-030b-0598-c8a2" name="Multi-melta">
+                  <costs>
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                    <cost typeId="points" value="20" name="pts" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::8497-0034-668a-a40a::f137-6527-ee90-112e::1768-d7b9-37ba-f3bf" name="Multi-melta">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">24"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Heavy 2</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">8</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">-4</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">D6</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Each time an attack made with this weapon targets a unit within half range, that attack has a Damage characteristic of D6+2.</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+              </selections>
+              <rules />
+              <profiles />
+            </selection>
+            <selection number="1" type="model" entryId="35c0-8dc5-d8cc-f847::ccd7-6d4c-d706-5fe9" entryGroupId="35c0-8dc5-d8cc-f847::06f2-6ce7-3c52-a6bc" id="cd02-8876-13e4-eaa9" name="Devastator Marine w/Heavy Weapon">
+              <costs>
+                <cost typeId="points" value="18" name="pts" />
+                <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+              </costs>
+              <categories />
+              <selections>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::8c98-ff8d-e199-fc77::37d3-7098-d596-9948" id="827c-b9aa-fa71-3df6" name="Bolt pistol">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::8c98-ff8d-e199-fc77::113b-392d-19be-cffa::e6d5-677a-d8ed-f6a5" name="Bolt pistol">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">12"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Pistol 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">4</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::cddf-945e-1335-e681" id="04ff-f8c1-079f-60ba" name="Frag &amp; Krak grenades">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::61a4-e2d3-522d-c838::fdd8-1a5f-5722-d6ee" name="Frag grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade D6</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">3</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Blast.</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::b250-1f2e-4904-0eb4::3bf6-b4f7-6b2f-bb7b" name="Krak grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">6</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">-1</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">D3</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::abbe-1edb-7509-d4dd::05ab-e7cc-e856-c36f" entryGroupId="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::026f-f4dc-9e33-cd9d" id="ee91-c17b-f5e1-e1d0" name="Heavy bolter">
+                  <costs>
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                    <cost typeId="points" value="10" name="pts" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::abbe-1edb-7509-d4dd::f5ff-ee10-df57-d926::e2b0-b9f1-6c38-584c" name="Heavy bolter">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">36"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Heavy 3</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">5</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">-1</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">2</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+              </selections>
+              <rules />
+              <profiles />
+            </selection>
+            <selection number="1" type="model" entryId="35c0-8dc5-d8cc-f847::ccd7-6d4c-d706-5fe9" entryGroupId="35c0-8dc5-d8cc-f847::06f2-6ce7-3c52-a6bc" id="cc31-67a6-0063-d052" name="Devastator Marine w/Heavy Weapon">
+              <costs>
+                <cost typeId="points" value="18" name="pts" />
+                <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+              </costs>
+              <categories />
+              <selections>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::8c98-ff8d-e199-fc77::37d3-7098-d596-9948" id="e58a-d43c-8810-0186" name="Bolt pistol">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::8c98-ff8d-e199-fc77::113b-392d-19be-cffa::e6d5-677a-d8ed-f6a5" name="Bolt pistol">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">12"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Pistol 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">4</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::cddf-945e-1335-e681" id="99e2-8359-d218-344b" name="Frag &amp; Krak grenades">
+                  <costs>
+                    <cost typeId="points" value="0" name="pts" />
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::61a4-e2d3-522d-c838::fdd8-1a5f-5722-d6ee" name="Frag grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade D6</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">3</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">0</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">1</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Blast.</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::4082-4267-5f27-94e4::b250-1f2e-4904-0eb4::3bf6-b4f7-6b2f-bb7b" name="Krak grenades">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">6"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Grenade 1</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">6</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">-1</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">D3</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">-</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+                <selection number="1" type="upgrade" entryId="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::8497-0034-668a-a40a::2b37-65ee-9443-b4ef" entryGroupId="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::026f-f4dc-9e33-cd9d" id="9f8a-fcf8-42a9-246c" name="Multi-melta">
+                  <costs>
+                    <cost typeId="e356-c769-5920-6e14" value="0" name=" PL" />
+                    <cost typeId="2d3b-b544-ad49-fb75" value="0" name="CP" />
+                    <cost typeId="points" value="20" name="pts" />
+                  </costs>
+                  <categories />
+                  <selections />
+                  <rules />
+                  <profiles>
+                    <profile typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon" hidden="false" id="35c0-8dc5-d8cc-f847::1952-5bdc-055c-5537::8497-0034-668a-a40a::f137-6527-ee90-112e::1768-d7b9-37ba-f3bf" name="Multi-melta">
+                      <characteristics>
+                        <characteristic typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range">24"</characteristic>
+                        <characteristic typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type">Heavy 2</characteristic>
+                        <characteristic typeId="59b1-319e-ec13-d466" name="S">8</characteristic>
+                        <characteristic typeId="75aa-a838-b675-6484" name="AP">-4</characteristic>
+                        <characteristic typeId="ae8a-3137-d65b-4ca7" name="D">D6</characteristic>
+                        <characteristic typeId="837d-5e63-aeb7-1410" name="Abilities">Each time an attack made with this weapon targets a unit within half range, that attack has a Damage characteristic of D6+2.</characteristic>
+                      </characteristics>
+                      <modifiers />
+                      <modifierGroups />
+                    </profile>
+                  </profiles>
+                </selection>
+              </selections>
+              <rules />
+              <profiles />
+            </selection>
+          </selections>
+          <rules>
+            <rule hidden="false" id="35c0-8dc5-d8cc-f847::804d-534d-7167-07d3::01a4-bec8-b573-fde7" name="Angels of Death">
+              <description>This unit has the following abilities: And They Shall Know No Fear, Bolter Discipline, Shock Assault and Combat Doctrines.</description>
+              <modifiers />
+              <modifierGroups />
+            </rule>
+            <rule hidden="false" id="35c0-8dc5-d8cc-f847::004a-8a3e-0338-e465::af4f-5849-3bd3-e2fd" name="Combat Squads">
+              <description>Before any models are deployed at the start of the game, this unit when containing its maximum number of models, may be split into two units each containing an equal number of models.</description>
+              <modifiers />
+              <modifierGroups />
+            </rule>
+          </rules>
+          <profiles>
+            <profile typeId="800f-21d0-4387-c943" typeName="Unit" hidden="false" id="35c0-8dc5-d8cc-f847::657c-2e23-d319-9dfe::7d5b-5e9e-c1e4-d8d2" name="Devastator Marine">
+              <characteristics>
+                <characteristic typeId="0bdf-a96e-9e38-7779" name="M">6"</characteristic>
+                <characteristic typeId="e7f0-1278-0250-df0c" name="WS">3+</characteristic>
+                <characteristic typeId="381b-eb28-74c3-df5f" name="BS">3+</characteristic>
+                <characteristic typeId="2218-aa3c-265f-2939" name="S">4</characteristic>
+                <characteristic typeId="9c9f-9774-a358-3a39" name="T">4</characteristic>
+                <characteristic typeId="f330-5e6e-4110-0978" name="W">2</characteristic>
+                <characteristic typeId="13fc-b29b-31f2-ab9f" name="A">1</characteristic>
+                <characteristic typeId="00ca-f8b8-876d-b705" name="Ld">7</characteristic>
+                <characteristic typeId="c0df-df94-abd7-e8d3" name="Save">3+</characteristic>
+              </characteristics>
+              <modifiers />
+              <modifierGroups />
+            </profile>
+            <profile typeId="800f-21d0-4387-c943" typeName="Unit" hidden="false" id="35c0-8dc5-d8cc-f847::abf4-20b5-0181-17ab::cdb4-e266-8c8b-b51c" name="Devastator Marine Sergeant">
+              <characteristics>
+                <characteristic typeId="0bdf-a96e-9e38-7779" name="M">6"</characteristic>
+                <characteristic typeId="e7f0-1278-0250-df0c" name="WS">3+</characteristic>
+                <characteristic typeId="381b-eb28-74c3-df5f" name="BS">3+</characteristic>
+                <characteristic typeId="2218-aa3c-265f-2939" name="S">4</characteristic>
+                <characteristic typeId="9c9f-9774-a358-3a39" name="T">4</characteristic>
+                <characteristic typeId="f330-5e6e-4110-0978" name="W">2</characteristic>
+                <characteristic typeId="13fc-b29b-31f2-ab9f" name="A">2</characteristic>
+                <characteristic typeId="00ca-f8b8-876d-b705" name="Ld">8</characteristic>
+                <characteristic typeId="c0df-df94-abd7-e8d3" name="Save">3+</characteristic>
+              </characteristics>
+              <modifiers />
+              <modifierGroups />
+            </profile>
+            <profile typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities" hidden="false" id="35c0-8dc5-d8cc-f847::60ba-de35-8ebd-75fb::06e9-cf5a-6396-b114" name="Signum">
+              <characteristics>
+                <characteristic typeId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description">In your Shooting phase, each time this unit shoots, if it contains a Devastator Marine Sergeant, you can select one model in this unit. Until the end of the phase, that model has a Ballistic Skill characteristic of 2+. </characteristic>
               </characteristics>
               <modifiers />
               <modifierGroups />


### PR DESCRIPTION
1) Prefer a weapon's selection name instead of the weapon's profile name when listing model loadouts.

This fixes the case where a selection named "Two guns" has number=1 and a single profile for "gun" -- previously, this would show up as "model (1x gun)". Also fixes loadout for combi weapons and cleans up loadout for weapons with multiple profiles.

2) dedupe model list loadouts by sorting models by name as well as gear

3) cover case where a roster's selection has an upgrade that has a unit that has a model

4) While we're at it, dedup model stats lines.

5) add zip file handling for tests