### PR TITLE
Fixed issue with EP display in header for KT21

### DIFF
--- a/src/rosterKT21.ts
+++ b/src/rosterKT21.ts
@@ -483,7 +483,7 @@ function ParseOperative(root: Element): Operative | null {
             let which = cost.getAttributeNode("name")?.nodeValue;
             let value = cost.getAttributeNode("value")?.nodeValue;
             if (which == " EP" && value && +value > 0) {
-                operative._costs = operative.costs() + value;
+                operative._costs = (operative.costs() + parseInt(value)).toString();
             }
         }
     }


### PR DESCRIPTION
If a unit had two pieces of equipement, their values were string
concatinated together rather than added. i.e "23" instead of "5"