### PR TITLE
40k: add stratagems to roster summary

### DIFF
--- a/spec/AeldariTestSpec.ts
+++ b/spec/AeldariTestSpec.ts
@@ -12,284 +12,297 @@ describe("Create40kRoster", function() {
         '_points': 1669,
         '_commandPoints': 9,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Farseer",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Farseer"}),
-              ],
-              '_modelList': [
-                "Farseer (Shuriken Pistol, Witchblade, 0. Smite, Ghosthelm, Psyker (Farseer), Rune Armour, Runes of the Farseer, Warlord)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shuriken pistol"}),
-                jasmine.objectContaining({'_name': "Witchblade"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Psyker (Farseer)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Jain Zar",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Jain Zar"}),
-              ],
-              '_modelList': [
-                "Jain Zar (Silent Death, Blade of Destruction, Acrobatic, Banshee Mask, Cry of War Unending, The Storm of Silence, War Shout)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Silent Death"}),
-                jasmine.objectContaining({'_name': "Blade of Destruction"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Dire Avengers",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Dire Avenger"}),
-              ],
-              '_modelList': [
-                "5x Dire Avenger (Avenger Shuriken Catapult, Plasma Grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Avenger Shuriken Catapult"}),
-                jasmine.objectContaining({'_name': "Plasma Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Rangers",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Ranger"}),
-              ],
-              '_modelList': [
-                "5x Ranger (Ranger Long Rifle, Shuriken Pistol)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Ranger Long Rifle"}),
-                jasmine.objectContaining({'_name': "Shuriken pistol"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Storm Guardians",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Storm Guardian"}),
-              ],
-              '_modelList': [
-                "8x Storm Guardian - Aeldari Blade (Shuriken Pistol, Aeldari Blade, Plasma Grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shuriken pistol"}),
-                jasmine.objectContaining({'_name': "Aeldari Blade"}),
-                jasmine.objectContaining({'_name': "Plasma Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Wraithlord",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Wraithlord"}),
-              ],
-              '_modelList': [
-                "Wraithlord (2x Shuriken Catapult, Wraithbone Fists)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shuriken Catapult"}),
-                jasmine.objectContaining({'_name': "Wraithbone Fists"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Wraithlord 1."}),
-                jasmine.objectContaining({'_name': "Wraithlord 2."}),
-                jasmine.objectContaining({'_name': "Wraithlord 3."}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Crimson Hunter",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Crimson Hunter"}),
-              ],
-              '_modelList': [
-                "Crimson Hunter (2x Bright Lance, Pulse Laser, Airborne, Crash and Burn, Hard to Hit, Skyhunters, Wings of Khaine)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bright Lance"}),
-                jasmine.objectContaining({'_name': "Pulse Laser"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Crimson Hunter 1."}),
-                jasmine.objectContaining({'_name': "Crimson Hunter 2."}),
-                jasmine.objectContaining({'_name': "Crimson Hunter 3."}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Crimson Hunter Exarch",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Crimson Hunter Exarch"}),
-              ],
-              '_modelList': [
-                "Crimson Hunter Exarch (Two Bright Lances, Pulse Laser, Airborne, Crash and Burn, Hard to Hit, Marksman's Eye, Skyhunters, Wings of Khaine)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bright Lance"}),
-                jasmine.objectContaining({'_name': "Pulse Laser"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Crimson Hunter Exarch 1."}),
-                jasmine.objectContaining({'_name': "Crimson Hunter Exarch 2."}),
-                jasmine.objectContaining({'_name': "Crimson Hunter Exarch 3."}),
-              ]}),
-          ]}),
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Succubus",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Succubus"}),
-              ],
-              '_modelList': [
-                "Succubus (Splinter pistol, Archite Glaive)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter pistol"}),
-                jasmine.objectContaining({'_name': "Archite glaive"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Urien Rakarth",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Urien Rakarth"}),
-              ],
-              '_modelList': [
-                "Urien Rakarth (Casket of Flensing, Haemonculus tools, Ichor Injector)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Casket of Flensing"}),
-                jasmine.objectContaining({'_name': "Haemonculus tools"}),
-                jasmine.objectContaining({'_name': "Ichor Injector"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Kabalite Warriors",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Kabalite Warrior"}),
-                jasmine.objectContaining({'_name': "Sybarite"}),
-              ],
-              '_modelList': [
-                "4x Kabalite Warrior (Splinter Rifle)",
-                "Sybarite (Splinter Rifle)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter rifle"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Wracks",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Acothyst"}),
-                jasmine.objectContaining({'_name': "Wracks"}),
-              ],
-              '_modelList': [
-                "Acothyst (Haemonculus tools)",
-                "4x Wracks (Haemonculus Tools)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Haemonculus tools"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Wyches",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Hekatrix"}),
-                jasmine.objectContaining({'_name': "Wych"}),
-              ],
-              '_modelList': [
-                "Hekatrix (Splinter pistol, Hekatarii blade, Plasma Grenade)",
-                "4x Wych (Splinter Pistol, Hekatarii blade, Plasma Grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter pistol"}),
-                jasmine.objectContaining({'_name': "Hekatarii blade"}),
-                jasmine.objectContaining({'_name': "Plasma Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Incubi",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Incubi"}),
-                jasmine.objectContaining({'_name': "Klaivex"}),
-              ],
-              '_modelList': [
-                "4x Incubi (Klaive)",
-                "Klaivex (Klaive)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Klaive"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Scourges",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Scourge"}),
-                jasmine.objectContaining({'_name': "Solarite"}),
-              ],
-              '_modelList': [
-                "4x Scourge w/ shardcarbine (Shardcarbine, Plasma Grenade)",
-                "Solarite (Shardcarbine, Plasma Grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shardcarbine"}),
-                jasmine.objectContaining({'_name': "Plasma Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Ravager",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Ravager"}),
-              ],
-              '_modelList': [
-                "Ravager (3x Dark Lance, Bladevanes, Night Shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Dark Lance"}),
-                jasmine.objectContaining({'_name': "Bladevanes"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Ravager"}),
-                jasmine.objectContaining({'_name': "Ravager 1"}),
-                jasmine.objectContaining({'_name': "Ravager 3"}),
-                jasmine.objectContaining({'_name': "Ravager 2"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Reaper",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Reaper"}),
-              ],
-              '_modelList': [
-                "Reaper (Storm Vortex Projector, Scythevanes, Sharpened prow blade, Night Shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Storm Vortex Projector - Beam"}),
-                jasmine.objectContaining({'_name': "Storm Vortex Projector - Blast"}),
-                jasmine.objectContaining({'_name': "Scythevanes"}),
-                jasmine.objectContaining({'_name': "Sharpened prow blade"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Reaper"}),
-                jasmine.objectContaining({'_name': "Reaper 1"}),
-                jasmine.objectContaining({'_name': "Reaper 2"}),
-                jasmine.objectContaining({'_name': "Reaper 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Talos",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Talos"}),
-              ],
-              '_modelList': [
-                "Talos (2x Splinter Cannon, 2x Macro-Scalpel)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter Cannon"}),
-                jasmine.objectContaining({'_name': "Macro-Scalpel"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Venom",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Venom"}),
-              ],
-              '_modelList': [
-                "Venom (Splinter Cannon, Twin splinter rifle, Bladevanes, Flickerfield, Night Shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter Cannon"}),
-                jasmine.objectContaining({'_name': "Twin splinter rifle"}),
-                jasmine.objectContaining({'_name': "Bladevanes"}),
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [
+              "Faction: <Craftworld> - Craftworld Attribute: Alaitoc: Fieldcraft",
+              "Battle-forged CP",
+              "Detachment CP",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Farseer",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Farseer"}),
+                ],
+                '_modelList': [
+                  "Farseer (Shuriken Pistol, Witchblade, 0. Smite, Ghosthelm, Psyker (Farseer), Rune Armour, Runes of the Farseer, Warlord)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shuriken pistol"}),
+                  jasmine.objectContaining({'_name': "Witchblade"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Psyker (Farseer)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Jain Zar",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Jain Zar"}),
+                ],
+                '_modelList': [
+                  "Jain Zar (Silent Death, Blade of Destruction, Acrobatic, Banshee Mask, Cry of War Unending, The Storm of Silence, War Shout)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Silent Death"}),
+                  jasmine.objectContaining({'_name': "Blade of Destruction"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Dire Avengers",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Dire Avenger"}),
+                ],
+                '_modelList': [
+                  "5x Dire Avenger (Avenger Shuriken Catapult, Plasma Grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Avenger Shuriken Catapult"}),
+                  jasmine.objectContaining({'_name': "Plasma Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Rangers",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Ranger"}),
+                ],
+                '_modelList': [
+                  "5x Ranger (Ranger Long Rifle, Shuriken Pistol)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Ranger Long Rifle"}),
+                  jasmine.objectContaining({'_name': "Shuriken pistol"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Storm Guardians",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Storm Guardian"}),
+                ],
+                '_modelList': [
+                  "8x Storm Guardian - Aeldari Blade (Shuriken Pistol, Aeldari Blade, Plasma Grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shuriken pistol"}),
+                  jasmine.objectContaining({'_name': "Aeldari Blade"}),
+                  jasmine.objectContaining({'_name': "Plasma Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Wraithlord",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Wraithlord"}),
+                ],
+                '_modelList': [
+                  "Wraithlord (2x Shuriken Catapult, Wraithbone Fists)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shuriken Catapult"}),
+                  jasmine.objectContaining({'_name': "Wraithbone Fists"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Wraithlord 1."}),
+                  jasmine.objectContaining({'_name': "Wraithlord 2."}),
+                  jasmine.objectContaining({'_name': "Wraithlord 3."}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Crimson Hunter",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Crimson Hunter"}),
+                ],
+                '_modelList': [
+                  "Crimson Hunter (2x Bright Lance, Pulse Laser, Airborne, Crash and Burn, Hard to Hit, Skyhunters, Wings of Khaine)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bright Lance"}),
+                  jasmine.objectContaining({'_name': "Pulse Laser"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Crimson Hunter 1."}),
+                  jasmine.objectContaining({'_name': "Crimson Hunter 2."}),
+                  jasmine.objectContaining({'_name': "Crimson Hunter 3."}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Crimson Hunter Exarch",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Crimson Hunter Exarch"}),
+                ],
+                '_modelList': [
+                  "Crimson Hunter Exarch (Two Bright Lances, Pulse Laser, Airborne, Crash and Burn, Hard to Hit, Marksman's Eye, Skyhunters, Wings of Khaine)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bright Lance"}),
+                  jasmine.objectContaining({'_name': "Pulse Laser"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Crimson Hunter Exarch 1."}),
+                  jasmine.objectContaining({'_name': "Crimson Hunter Exarch 2."}),
+                  jasmine.objectContaining({'_name': "Crimson Hunter Exarch 3."}),
+                ]}),
+            ]
+          }),
+          jasmine.objectContaining({
+            '_configurations': [
+              "Detachment Type: Mixed Detachment",
+              "Detachment CP",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Succubus",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Succubus"}),
+                ],
+                '_modelList': [
+                  "Succubus (Splinter pistol, Archite Glaive)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter pistol"}),
+                  jasmine.objectContaining({'_name': "Archite glaive"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Urien Rakarth",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Urien Rakarth"}),
+                ],
+                '_modelList': [
+                  "Urien Rakarth (Casket of Flensing, Haemonculus tools, Ichor Injector)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Casket of Flensing"}),
+                  jasmine.objectContaining({'_name': "Haemonculus tools"}),
+                  jasmine.objectContaining({'_name': "Ichor Injector"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Kabalite Warriors",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Kabalite Warrior"}),
+                  jasmine.objectContaining({'_name': "Sybarite"}),
+                ],
+                '_modelList': [
+                  "4x Kabalite Warrior (Splinter Rifle)",
+                  "Sybarite (Splinter Rifle)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter rifle"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Wracks",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Acothyst"}),
+                  jasmine.objectContaining({'_name': "Wracks"}),
+                ],
+                '_modelList': [
+                  "Acothyst (Haemonculus tools)",
+                  "4x Wracks (Haemonculus Tools)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Haemonculus tools"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Wyches",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Hekatrix"}),
+                  jasmine.objectContaining({'_name': "Wych"}),
+                ],
+                '_modelList': [
+                  "Hekatrix (Splinter pistol, Hekatarii blade, Plasma Grenade)",
+                  "4x Wych (Splinter Pistol, Hekatarii blade, Plasma Grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter pistol"}),
+                  jasmine.objectContaining({'_name': "Hekatarii blade"}),
+                  jasmine.objectContaining({'_name': "Plasma Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Incubi",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Incubi"}),
+                  jasmine.objectContaining({'_name': "Klaivex"}),
+                ],
+                '_modelList': [
+                  "4x Incubi (Klaive)",
+                  "Klaivex (Klaive)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Klaive"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Scourges",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Scourge"}),
+                  jasmine.objectContaining({'_name': "Solarite"}),
+                ],
+                '_modelList': [
+                  "4x Scourge w/ shardcarbine (Shardcarbine, Plasma Grenade)",
+                  "Solarite (Shardcarbine, Plasma Grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shardcarbine"}),
+                  jasmine.objectContaining({'_name': "Plasma Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Ravager",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Ravager"}),
+                ],
+                '_modelList': [
+                  "Ravager (3x Dark Lance, Bladevanes, Night Shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Dark Lance"}),
+                  jasmine.objectContaining({'_name': "Bladevanes"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Ravager"}),
+                  jasmine.objectContaining({'_name': "Ravager 1"}),
+                  jasmine.objectContaining({'_name': "Ravager 3"}),
+                  jasmine.objectContaining({'_name': "Ravager 2"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Reaper",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Reaper"}),
+                ],
+                '_modelList': [
+                  "Reaper (Storm Vortex Projector, Scythevanes, Sharpened prow blade, Night Shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Storm Vortex Projector - Beam"}),
+                  jasmine.objectContaining({'_name': "Storm Vortex Projector - Blast"}),
+                  jasmine.objectContaining({'_name': "Scythevanes"}),
+                  jasmine.objectContaining({'_name': "Sharpened prow blade"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Reaper"}),
+                  jasmine.objectContaining({'_name': "Reaper 1"}),
+                  jasmine.objectContaining({'_name': "Reaper 2"}),
+                  jasmine.objectContaining({'_name': "Reaper 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Talos",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Talos"}),
+                ],
+                '_modelList': [
+                  "Talos (2x Splinter Cannon, 2x Macro-Scalpel)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter Cannon"}),
+                  jasmine.objectContaining({'_name': "Macro-Scalpel"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Venom",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Venom"}),
+                ],
+                '_modelList': [
+                  "Venom (Splinter Cannon, Twin splinter rifle, Bladevanes, Flickerfield, Night Shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter Cannon"}),
+                  jasmine.objectContaining({'_name': "Twin splinter rifle"}),
+                  jasmine.objectContaining({'_name': "Bladevanes"}),
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/BlackTemplar-TestOutputSpec.ts
+++ b/spec/BlackTemplar-TestOutputSpec.ts
@@ -12,342 +12,351 @@ describe("Create40kRoster", function() {
         '_points': 2087,
         '_commandPoints': -3,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Chapter Master in Phobos Armor",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Chapter Master in Phobos Armor (Stratagem: Chapter Master)"}),
-              ],
-              '_modelList': [
-                "Chapter Master in Phobos Armor (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Frontline Commander, Stratagem: Chapter Master [-2 CP], Stratagem: Hero of the Chapter [-1 CP])"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted instigator bolt carbine"}),
-                jasmine.objectContaining({'_name': "Combat knife"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Primaris Lieutenants",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Primaris Lieutenants"}),
-              ],
-              '_modelList': [
-                "Primaris Lieutenants (Bolt pistol, Master-crafted auto bolt rifle, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted auto bolt rifle"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Scout Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Scout"}),
-                jasmine.objectContaining({'_name': "Scout Sergeant"}),
-              ],
-              '_modelList': [
-                "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tactical Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
-              ],
-              '_modelList': [
-                "6x Space Marine (7x Bolt pistol, Boltgun, Grav-gun, 7x Frag & Krak grenades)",
-                "Space Marine Sergeant (2x Bolt pistol, Boltgun, Grav-gun, 2x Frag & Krak grenades, Melta bombs)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Grav-gun"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-                jasmine.objectContaining({'_name': "Melta bomb"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tactical Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
-              ],
-              '_modelList': [
-                "4x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "**Chapter Selection**",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Chaplain Grimaldus",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Chaplain Grimaldus"}),
-              ],
-              '_modelList': [
-                "Chaplain Grimaldus (Plasma pistol, Artificer Crozius, Frag & Krak grenades, 1. Litany of Divine Protection, 3. Vow of Retribution, Litany of Hate)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Plasma pistol, Standard"}),
-                jasmine.objectContaining({'_name': "Plasma pistol, Supercharge"}),
-                jasmine.objectContaining({'_name': "Artificer Crozius"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "The Emperor's Champion",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Emperor's Champion"}),
-              ],
-              '_modelList': [
-                "The Emperor's Champion (Bolt pistol, Black Sword, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Black Sword"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Crusader Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Initiate"}),
-                jasmine.objectContaining({'_name': "Sword Brother"}),
-              ],
-              '_modelList': [
-                "3x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
-                "Initiate w/Heavy or Melee Weapon (Bolt pistol, Lascannon, Frag & Krak grenades)",
-                "Sword Brother (Bolt pistol, Power axe, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Lascannon"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Power axe"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Crusader Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Initiate"}),
-                jasmine.objectContaining({'_name': "Neophyte"}),
-                jasmine.objectContaining({'_name': "Sword Brother"}),
-              ],
-              '_modelList': [
-                "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Initiate w/Special Weapon (Bolt pistol, Grav-gun, Frag & Krak grenades)",
-                "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag & Krak grenades)",
-                "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Astartes shotgun"}),
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Grav-gun"}),
-                jasmine.objectContaining({'_name': "Power fist"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Crusader Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Initiate"}),
-                jasmine.objectContaining({'_name': "Neophyte"}),
-                jasmine.objectContaining({'_name': "Sword Brother"}),
-              ],
-              '_modelList': [
-                "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
-                "Initiate w/Heavy or Melee Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
-                "Neophyte w/Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Neophyte w/Combat Knife (Bolt pistol, Combat knife, Frag & Krak grenades)",
-                "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag & Krak grenades)",
-                "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Astartes shotgun"}),
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Combat knife"}),
-                jasmine.objectContaining({'_name': "Power fist"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "**Chapter Selection**",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Lieutenants in Phobos Armor",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
-              ],
-              '_modelList': [
-                "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag & Krak grenades, Grav-chute)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted occulus bolt rifle"}),
-                jasmine.objectContaining({'_name': "Paired Combat Blades"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Centurion Devastator Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Centurion"}),
-                jasmine.objectContaining({'_name': "Centurion Sergeant"}),
-              ],
-              '_modelList': [
-                "Centurion Devastator Squad (3x Two Heavy Bolters, 3x Hurricane bolter)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-                jasmine.objectContaining({'_name': "Hurricane bolter"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Devastator Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
-              ],
-              '_modelList': [
-                "Devastator Squad (5x Bolt pistol, Grav-cannon and grav-amp, Grav-pistol, 2x Heavy bolter, Multi-melta, Chainsword, 5x Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Grav-cannon and grav-amp"}),
-                jasmine.objectContaining({'_name': "Grav-pistol"}),
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-                jasmine.objectContaining({'_name': "Multi-melta"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Eliminator Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Eliminator"}),
-                jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
-              ],
-              '_modelList': [
-                "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)",
-                "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle - Executioner round"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle - Hyperfrag round"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle - Mortis round"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Repulsor Executioner",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Repulsor Executioner"}),
-              ],
-              '_modelList': [
-                "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Icarus Rocket Pod, Ironhail Heavy Stubber, Macro Plasma Incinerator, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber, Auto Launchers)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
-                jasmine.objectContaining({'_name': "Icarus Rocket Pod"}),
-                jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
-                jasmine.objectContaining({'_name': "Macro Plasma Incinerator, Standard"}),
-                jasmine.objectContaining({'_name': "Macro Plasma Incinerator, Supercharged"}),
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-                jasmine.objectContaining({'_name': "Twin Heavy Bolter"}),
-                jasmine.objectContaining({'_name': "Twin Icarus Ironhail Heavy Stubber"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Repulsor Executioner 1"}),
-                jasmine.objectContaining({'_name': "Repulsor Executioner 2"}),
-                jasmine.objectContaining({'_name': "Repulsor Executioner 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Drop Pod",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Drop Pod"}),
-              ],
-              '_modelList': [
-                "Drop Pod (Storm bolter)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Repulsor",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Repulsor"}),
-              ],
-              '_modelList': [
-                "Repulsor (Heavy Onslaught Gatling Cannon, Icarus Ironhail Heavy Stubber, 2x Ironhail Heavy Stubber, 2x Krakstorm Grenade Launcher, 2x Storm Bolters, Twin heavy bolter, Auto Launchers)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
-                jasmine.objectContaining({'_name': "Icarus Ironhail Heavy Stubber"}),
-                jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
-                jasmine.objectContaining({'_name': "Krakstorm Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-                jasmine.objectContaining({'_name': "Twin heavy bolter"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Repulsor 1"}),
-                jasmine.objectContaining({'_name': "Repulsor 2"}),
-                jasmine.objectContaining({'_name': "Repulsor 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "**Chapter Selection**",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Chapter Master in Phobos Armor",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Chapter Master in Phobos Armor (Stratagem: Chapter Master)"}),
+                ],
+                '_modelList': [
+                  "Chapter Master in Phobos Armor (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Frontline Commander, Stratagem: Chapter Master [-2 CP], Stratagem: Hero of the Chapter [-1 CP])"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted instigator bolt carbine"}),
+                  jasmine.objectContaining({'_name': "Combat knife"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Primaris Lieutenants",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Primaris Lieutenants"}),
+                ],
+                '_modelList': [
+                  "Primaris Lieutenants (Bolt pistol, Master-crafted auto bolt rifle, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted auto bolt rifle"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Scout Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Scout"}),
+                  jasmine.objectContaining({'_name': "Scout Sergeant"}),
+                ],
+                '_modelList': [
+                  "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tactical Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
+                ],
+                '_modelList': [
+                  "6x Space Marine (7x Bolt pistol, Boltgun, Grav-gun, 7x Frag & Krak grenades)",
+                  "Space Marine Sergeant (2x Bolt pistol, Boltgun, Grav-gun, 2x Frag & Krak grenades, Melta bombs)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Grav-gun"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                  jasmine.objectContaining({'_name': "Melta bomb"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tactical Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
+                ],
+                '_modelList': [
+                  "4x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "**Chapter Selection**",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Chaplain Grimaldus",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Chaplain Grimaldus"}),
+                ],
+                '_modelList': [
+                  "Chaplain Grimaldus (Plasma pistol, Artificer Crozius, Frag & Krak grenades, 1. Litany of Divine Protection, 3. Vow of Retribution, Litany of Hate)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Plasma pistol, Standard"}),
+                  jasmine.objectContaining({'_name': "Plasma pistol, Supercharge"}),
+                  jasmine.objectContaining({'_name': "Artificer Crozius"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "The Emperor's Champion",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Emperor's Champion"}),
+                ],
+                '_modelList': [
+                  "The Emperor's Champion (Bolt pistol, Black Sword, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Black Sword"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Crusader Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Initiate"}),
+                  jasmine.objectContaining({'_name': "Sword Brother"}),
+                ],
+                '_modelList': [
+                  "3x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
+                  "Initiate w/Heavy or Melee Weapon (Bolt pistol, Lascannon, Frag & Krak grenades)",
+                  "Sword Brother (Bolt pistol, Power axe, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Lascannon"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Power axe"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Crusader Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Initiate"}),
+                  jasmine.objectContaining({'_name': "Neophyte"}),
+                  jasmine.objectContaining({'_name': "Sword Brother"}),
+                ],
+                '_modelList': [
+                  "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Initiate w/Special Weapon (Bolt pistol, Grav-gun, Frag & Krak grenades)",
+                  "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag & Krak grenades)",
+                  "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Astartes shotgun"}),
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Grav-gun"}),
+                  jasmine.objectContaining({'_name': "Power fist"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Crusader Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Initiate"}),
+                  jasmine.objectContaining({'_name': "Neophyte"}),
+                  jasmine.objectContaining({'_name': "Sword Brother"}),
+                ],
+                '_modelList': [
+                  "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
+                  "Initiate w/Heavy or Melee Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
+                  "Neophyte w/Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Neophyte w/Combat Knife (Bolt pistol, Combat knife, Frag & Krak grenades)",
+                  "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag & Krak grenades)",
+                  "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Astartes shotgun"}),
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Combat knife"}),
+                  jasmine.objectContaining({'_name': "Power fist"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "**Chapter Selection**",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Lieutenants in Phobos Armor",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
+                ],
+                '_modelList': [
+                  "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag & Krak grenades, Grav-chute)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted occulus bolt rifle"}),
+                  jasmine.objectContaining({'_name': "Paired Combat Blades"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Centurion Devastator Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Centurion"}),
+                  jasmine.objectContaining({'_name': "Centurion Sergeant"}),
+                ],
+                '_modelList': [
+                  "Centurion Devastator Squad (3x Two Heavy Bolters, 3x Hurricane bolter)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                  jasmine.objectContaining({'_name': "Hurricane bolter"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Devastator Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
+                ],
+                '_modelList': [
+                  "Devastator Squad (5x Bolt pistol, Grav-cannon and grav-amp, Grav-pistol, 2x Heavy bolter, Multi-melta, Chainsword, 5x Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Grav-cannon and grav-amp"}),
+                  jasmine.objectContaining({'_name': "Grav-pistol"}),
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                  jasmine.objectContaining({'_name': "Multi-melta"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Eliminator Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Eliminator"}),
+                  jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
+                ],
+                '_modelList': [
+                  "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)",
+                  "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle - Executioner round"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle - Hyperfrag round"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle - Mortis round"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Repulsor Executioner",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Repulsor Executioner"}),
+                ],
+                '_modelList': [
+                  "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Icarus Rocket Pod, Ironhail Heavy Stubber, Macro Plasma Incinerator, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber, Auto Launchers)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
+                  jasmine.objectContaining({'_name': "Icarus Rocket Pod"}),
+                  jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
+                  jasmine.objectContaining({'_name': "Macro Plasma Incinerator, Standard"}),
+                  jasmine.objectContaining({'_name': "Macro Plasma Incinerator, Supercharged"}),
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                  jasmine.objectContaining({'_name': "Twin Heavy Bolter"}),
+                  jasmine.objectContaining({'_name': "Twin Icarus Ironhail Heavy Stubber"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Repulsor Executioner 1"}),
+                  jasmine.objectContaining({'_name': "Repulsor Executioner 2"}),
+                  jasmine.objectContaining({'_name': "Repulsor Executioner 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Drop Pod",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Drop Pod"}),
+                ],
+                '_modelList': [
+                  "Drop Pod (Storm bolter)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Repulsor",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Repulsor"}),
+                ],
+                '_modelList': [
+                  "Repulsor (Heavy Onslaught Gatling Cannon, Icarus Ironhail Heavy Stubber, 2x Ironhail Heavy Stubber, 2x Krakstorm Grenade Launcher, 2x Storm Bolters, Twin heavy bolter, Auto Launchers)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
+                  jasmine.objectContaining({'_name': "Icarus Ironhail Heavy Stubber"}),
+                  jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
+                  jasmine.objectContaining({'_name': "Krakstorm Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                  jasmine.objectContaining({'_name': "Twin heavy bolter"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Repulsor 1"}),
+                  jasmine.objectContaining({'_name': "Repulsor 2"}),
+                  jasmine.objectContaining({'_name': "Repulsor 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "**Chapter Selection**",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/BlackTemplar2000Spec.ts
+++ b/spec/BlackTemplar2000Spec.ts
@@ -12,361 +12,364 @@ describe("Create40kRoster", function() {
         '_points': 1994,
         '_commandPoints': 14,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Captain in Phobos Armour",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Captain in Phobos Armour"}),
-              ],
-              '_modelList': [
-                "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Champion of Humanity, Warlord)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted instigator bolt carbine"}),
-                jasmine.objectContaining({'_name': "Combat knife"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Lieutenants in Phobos Armor",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
-              ],
-              '_modelList': [
-                "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag & Krak grenades, Grav-chute, The Armour Indomitus)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted occulus bolt rifle"}),
-                jasmine.objectContaining({'_name': "Paired Combat Blades"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "The Emperor's Champion",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Emperor's Champion"}),
-              ],
-              '_modelList': [
-                "The Emperor's Champion (Bolt pistol, Black Sword, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Black Sword"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Crusader Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Initiate"}),
-                jasmine.objectContaining({'_name': "Sword Brother"}),
-              ],
-              '_modelList': [
-                "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Sword Brother (Boltgun, Power fist, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Power fist"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Infiltrator Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Infiltrator"}),
-                jasmine.objectContaining({'_name': "Infiltrator Sergeant"}),
-              ],
-              '_modelList': [
-                "4x Infilltrator (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)",
-                "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Marksman bolt carbine"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Intercessor Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Intercessor"}),
-                jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
-              ],
-              '_modelList': [
-                "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
-                "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Auto Bolt Rifle"}),
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Thunder hammer"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Intercessor Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Intercessor (Veteran Intercessors)"}),
-                jasmine.objectContaining({'_name': "Intercessor Sergeant (Veteran Intercessors)"}),
-              ],
-              '_modelList': [
-                "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
-                "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Auto Bolt Rifle"}),
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Thunder hammer"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Scout Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Scout"}),
-                jasmine.objectContaining({'_name': "Scout Sergeant"}),
-              ],
-              '_modelList': [
-                "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tactical Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
-              ],
-              '_modelList': [
-                "4x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Aggressor Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Aggressor"}),
-                jasmine.objectContaining({'_name': "Aggressor Sergeant"}),
-              ],
-              '_modelList': [
-                "2x Aggressor (Auto Boltstorm Gauntlets, Fragstorm Grenade Launcher)",
-                "Aggressor Sergeant (Auto Boltstorm Gauntlets, Fragstorm Grenade Launcher)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Auto Boltstorm Gauntlets (Shooting)"}),
-                jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Auto Boltstorm Gauntlets (Melee)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Cenobyte Servitors",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Cenobyte Servitors"}),
-              ],
-              '_modelList': [
-                "Cenobyte Servitors (3x Close Combat Weapon)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Close Combat Weapon"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Redemptor Dreadnought",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought"}),
-              ],
-              '_modelList': [
-                "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Heavy flamer"}),
-                jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
-                jasmine.objectContaining({'_name': "Redemptor Fist"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought 1"}),
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought 2"}),
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Assault Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine (Jump Pack)"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
-              ],
-              '_modelList': [
-                "Assault Squad (2x Bolt pistol/Chainsword, 2x Frag & Krak grenades, Bolt pistol, Chainsword, Jump Pack)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Assault Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine (Jump Pack)"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
-              ],
-              '_modelList': [
-                "Assault Squad (2x Bolt pistol/Chainsword, 2x Frag & Krak grenades, Bolt pistol, Chainsword, Jump Pack)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Suppressor Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Suppressor"}),
-                jasmine.objectContaining({'_name': "Suppressor Sergeant"}),
-              ],
-              '_modelList': [
-                "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)",
-                "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Accelerator autocannon"}),
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Eliminator Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Eliminator"}),
-                jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
-              ],
-              '_modelList': [
-                "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)",
-                "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle - Executioner round"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle - Hyperfrag round"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle - Mortis round"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Predator",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Predator"}),
-              ],
-              '_modelList': [
-                "Predator (Two Heavy Bolters, Storm bolter, Twin lascannon)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-                jasmine.objectContaining({'_name': "Twin lascannon"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Predator 1"}),
-                jasmine.objectContaining({'_name': "Predator 2"}),
-                jasmine.objectContaining({'_name': "Predator 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Repulsor Executioner",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Repulsor Executioner"}),
-              ],
-              '_modelList': [
-                "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Macro Plasma Incinerator, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber, Auto Launchers)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
-                jasmine.objectContaining({'_name': "Macro Plasma Incinerator, Standard"}),
-                jasmine.objectContaining({'_name': "Macro Plasma Incinerator, Supercharged"}),
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-                jasmine.objectContaining({'_name': "Twin Heavy Bolter"}),
-                jasmine.objectContaining({'_name': "Twin Icarus Ironhail Heavy Stubber"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Repulsor Executioner 1"}),
-                jasmine.objectContaining({'_name': "Repulsor Executioner 2"}),
-                jasmine.objectContaining({'_name': "Repulsor Executioner 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Drop Pod",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Drop Pod"}),
-              ],
-              '_modelList': [
-                "Drop Pod (Storm bolter)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Impulsor",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Impulsor"}),
-              ],
-              '_modelList': [
-                "Impulsor (Ironhail Heavy Stubber, 2x Storm Bolters, Shield Dome)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Impulsor Wound Track 1"}),
-                jasmine.objectContaining({'_name': "Impulsor Wound Track 2"}),
-                jasmine.objectContaining({'_name': "Impulsor Wound Track 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "**Chapter Selection**",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Battle-forged CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Detachment CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Captain in Phobos Armour",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Captain in Phobos Armour"}),
+                ],
+                '_modelList': [
+                  "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Champion of Humanity, Warlord)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted instigator bolt carbine"}),
+                  jasmine.objectContaining({'_name': "Combat knife"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Lieutenants in Phobos Armor",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
+                ],
+                '_modelList': [
+                  "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag & Krak grenades, Grav-chute, The Armour Indomitus)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted occulus bolt rifle"}),
+                  jasmine.objectContaining({'_name': "Paired Combat Blades"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "The Emperor's Champion",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Emperor's Champion"}),
+                ],
+                '_modelList': [
+                  "The Emperor's Champion (Bolt pistol, Black Sword, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Black Sword"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Crusader Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Initiate"}),
+                  jasmine.objectContaining({'_name': "Sword Brother"}),
+                ],
+                '_modelList': [
+                  "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Sword Brother (Boltgun, Power fist, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Power fist"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Infiltrator Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Infiltrator"}),
+                  jasmine.objectContaining({'_name': "Infiltrator Sergeant"}),
+                ],
+                '_modelList': [
+                  "4x Infilltrator (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)",
+                  "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Marksman bolt carbine"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Intercessor Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Intercessor"}),
+                  jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
+                ],
+                '_modelList': [
+                  "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
+                  "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Auto Bolt Rifle"}),
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Thunder hammer"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Intercessor Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Intercessor (Veteran Intercessors)"}),
+                  jasmine.objectContaining({'_name': "Intercessor Sergeant (Veteran Intercessors)"}),
+                ],
+                '_modelList': [
+                  "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
+                  "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Auto Bolt Rifle"}),
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Thunder hammer"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Scout Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Scout"}),
+                  jasmine.objectContaining({'_name': "Scout Sergeant"}),
+                ],
+                '_modelList': [
+                  "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tactical Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
+                ],
+                '_modelList': [
+                  "4x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Aggressor Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Aggressor"}),
+                  jasmine.objectContaining({'_name': "Aggressor Sergeant"}),
+                ],
+                '_modelList': [
+                  "2x Aggressor (Auto Boltstorm Gauntlets, Fragstorm Grenade Launcher)",
+                  "Aggressor Sergeant (Auto Boltstorm Gauntlets, Fragstorm Grenade Launcher)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Auto Boltstorm Gauntlets (Shooting)"}),
+                  jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Auto Boltstorm Gauntlets (Melee)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Cenobyte Servitors",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Cenobyte Servitors"}),
+                ],
+                '_modelList': [
+                  "Cenobyte Servitors (3x Close Combat Weapon)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Close Combat Weapon"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Redemptor Dreadnought",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought"}),
+                ],
+                '_modelList': [
+                  "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Heavy flamer"}),
+                  jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
+                  jasmine.objectContaining({'_name': "Redemptor Fist"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought 1"}),
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought 2"}),
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Assault Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine (Jump Pack)"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
+                ],
+                '_modelList': [
+                  "Assault Squad (2x Bolt pistol/Chainsword, 2x Frag & Krak grenades, Bolt pistol, Chainsword, Jump Pack)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Assault Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine (Jump Pack)"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
+                ],
+                '_modelList': [
+                  "Assault Squad (2x Bolt pistol/Chainsword, 2x Frag & Krak grenades, Bolt pistol, Chainsword, Jump Pack)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Suppressor Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Suppressor"}),
+                  jasmine.objectContaining({'_name': "Suppressor Sergeant"}),
+                ],
+                '_modelList': [
+                  "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)",
+                  "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Accelerator autocannon"}),
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Eliminator Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Eliminator"}),
+                  jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
+                ],
+                '_modelList': [
+                  "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)",
+                  "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle - Executioner round"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle - Hyperfrag round"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle - Mortis round"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Predator",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Predator"}),
+                ],
+                '_modelList': [
+                  "Predator (Two Heavy Bolters, Storm bolter, Twin lascannon)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                  jasmine.objectContaining({'_name': "Twin lascannon"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Predator 1"}),
+                  jasmine.objectContaining({'_name': "Predator 2"}),
+                  jasmine.objectContaining({'_name': "Predator 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Repulsor Executioner",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Repulsor Executioner"}),
+                ],
+                '_modelList': [
+                  "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Macro Plasma Incinerator, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber, Auto Launchers)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
+                  jasmine.objectContaining({'_name': "Macro Plasma Incinerator, Standard"}),
+                  jasmine.objectContaining({'_name': "Macro Plasma Incinerator, Supercharged"}),
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                  jasmine.objectContaining({'_name': "Twin Heavy Bolter"}),
+                  jasmine.objectContaining({'_name': "Twin Icarus Ironhail Heavy Stubber"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Repulsor Executioner 1"}),
+                  jasmine.objectContaining({'_name': "Repulsor Executioner 2"}),
+                  jasmine.objectContaining({'_name': "Repulsor Executioner 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Drop Pod",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Drop Pod"}),
+                ],
+                '_modelList': [
+                  "Drop Pod (Storm bolter)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Impulsor",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Impulsor"}),
+                ],
+                '_modelList': [
+                  "Impulsor (Ironhail Heavy Stubber, 2x Storm Bolters, Shield Dome)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Impulsor Wound Track 1"}),
+                  jasmine.objectContaining({'_name': "Impulsor Wound Track 2"}),
+                  jasmine.objectContaining({'_name': "Impulsor Wound Track 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "**Chapter Selection**",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Battle-forged CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Detachment CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/BloodAngelstestSpec.ts
+++ b/spec/BloodAngelstestSpec.ts
@@ -12,92 +12,99 @@ describe("Create40kRoster", function() {
         '_points': 625,
         '_commandPoints': 1,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Lieutenants",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
-                jasmine.objectContaining({'_name': "Primaris Lieutenant"}),
-              ],
-              '_modelList': [
-                "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt carbine, Paired Combat Blades, Frag & Krak grenades)",
-                "Primaris Lieutenant (Bolt pistol, Neo-volkite pistol, Master-crafted power sword, Frag & Krak grenades, Storm shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted occulus bolt rifle"}),
-                jasmine.objectContaining({'_name': "Neo-volkite pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted power sword"}),
-                jasmine.objectContaining({'_name': "Paired Combat Blades"}),
-                jasmine.objectContaining({'_name': "Frag grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenades"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Assault Intercessor Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Assault Intercessor"}),
-                jasmine.objectContaining({'_name': "Assault Intercessor Sgt"}),
-              ],
-              '_modelList': [
-                "4x Assault Intercessor (Heavy Bolt Pistol, Astartes Chainsword, Frag & Krak grenades)",
-                "Assault Intercessor Sgt (Heavy Bolt Pistol, Astartes Chainsword, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
-                jasmine.objectContaining({'_name': "Astartes Chainsword"}),
-                jasmine.objectContaining({'_name': "Frag grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenades"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Bladeguard Veteran Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Bladeguard Veteran"}),
-                jasmine.objectContaining({'_name': "Bladeguard Veteran Sergeant"}),
-              ],
-              '_modelList': [
-                "2x Bladeguard Veteran (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm Shield)",
-                "Bladeguard Veteran Sergeant (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm Shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted power sword"}),
-                jasmine.objectContaining({'_name': "Frag grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenades"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Bladeguard Veteran Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Bladeguard Veteran"}),
-                jasmine.objectContaining({'_name': "Bladeguard Veteran Sergeant"}),
-              ],
-              '_modelList': [
-                "2x Bladeguard Veteran (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm Shield)",
-                "Bladeguard Veteran Sergeant (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm Shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted power sword"}),
-                jasmine.objectContaining({'_name': "Frag grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenades"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Outrider Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Outrider"}),
-                jasmine.objectContaining({'_name': "Outrider Sgt"}),
-              ],
-              '_modelList': [
-                "2x Outrider (Heavy Bolt Pistol, Twin Bolt rifle, Astartes Chainsword, Frag & Krak grenades)",
-                "Outrider Sgt (Heavy Bolt Pistol, Twin Bolt rifle, Astartes Chainsword, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
-                jasmine.objectContaining({'_name': "Twin Bolt rifle"}),
-                jasmine.objectContaining({'_name': "Astartes Chainsword"}),
-                jasmine.objectContaining({'_name': "Frag grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenades"}),
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [
+              "PC: BA - **Chapter Selector**: Blood Angels",
+              "Battle Size: 1. Combat Patrol (0-50 Total PL / 0-500 Points)  [3 CP]",
+              "Gametype: Matched",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Lieutenants",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
+                  jasmine.objectContaining({'_name': "Primaris Lieutenant"}),
+                ],
+                '_modelList': [
+                  "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt carbine, Paired Combat Blades, Frag & Krak grenades)",
+                  "Primaris Lieutenant (Bolt pistol, Neo-volkite pistol, Master-crafted power sword, Frag & Krak grenades, Storm shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted occulus bolt rifle"}),
+                  jasmine.objectContaining({'_name': "Neo-volkite pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted power sword"}),
+                  jasmine.objectContaining({'_name': "Paired Combat Blades"}),
+                  jasmine.objectContaining({'_name': "Frag grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenades"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Assault Intercessor Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Assault Intercessor"}),
+                  jasmine.objectContaining({'_name': "Assault Intercessor Sgt"}),
+                ],
+                '_modelList': [
+                  "4x Assault Intercessor (Heavy Bolt Pistol, Astartes Chainsword, Frag & Krak grenades)",
+                  "Assault Intercessor Sgt (Heavy Bolt Pistol, Astartes Chainsword, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
+                  jasmine.objectContaining({'_name': "Astartes Chainsword"}),
+                  jasmine.objectContaining({'_name': "Frag grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenades"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Bladeguard Veteran Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Bladeguard Veteran"}),
+                  jasmine.objectContaining({'_name': "Bladeguard Veteran Sergeant"}),
+                ],
+                '_modelList': [
+                  "2x Bladeguard Veteran (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm Shield)",
+                  "Bladeguard Veteran Sergeant (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm Shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted power sword"}),
+                  jasmine.objectContaining({'_name': "Frag grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenades"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Bladeguard Veteran Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Bladeguard Veteran"}),
+                  jasmine.objectContaining({'_name': "Bladeguard Veteran Sergeant"}),
+                ],
+                '_modelList': [
+                  "2x Bladeguard Veteran (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm Shield)",
+                  "Bladeguard Veteran Sergeant (Heavy Bolt Pistol, Master-crafted power sword, Frag & Krak grenades, Storm Shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted power sword"}),
+                  jasmine.objectContaining({'_name': "Frag grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenades"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Outrider Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Outrider"}),
+                  jasmine.objectContaining({'_name': "Outrider Sgt"}),
+                ],
+                '_modelList': [
+                  "2x Outrider (Heavy Bolt Pistol, Twin Bolt rifle, Astartes Chainsword, Frag & Krak grenades)",
+                  "Outrider Sgt (Heavy Bolt Pistol, Twin Bolt rifle, Astartes Chainsword, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy Bolt Pistol"}),
+                  jasmine.objectContaining({'_name': "Twin Bolt rifle"}),
+                  jasmine.objectContaining({'_name': "Astartes Chainsword"}),
+                  jasmine.objectContaining({'_name': "Frag grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenades"}),
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/ChaosSMTestSpec.ts
+++ b/spec/ChaosSMTestSpec.ts
@@ -12,383 +12,389 @@ describe("Create40kRoster", function() {
         '_points': 1973,
         '_commandPoints': 13,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Daemon Prince",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Daemon Prince"}),
-              ],
-              '_modelList': [
-                "Daemon Prince (Hellforged sword, Malefic talon)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Hellforged sword"}),
-                jasmine.objectContaining({'_name': "Malefic talon"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Lord Discordant on Helstalker",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Lord Discordant on Helstalker"}),
-              ],
-              '_modelList': [
-                "Lord Discordant on Helstalker (Autocannon, Bolt pistol, Bladed limbs and tail, Impaler chainglaive, Mechatendrils, Techno-virus injector, Frag & Krak grenades, 4. Hatred Incarnate, Intoxicating Elixir, Mark of Slaanesh, Warlord)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Autocannon"}),
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Bladed limbs and tail"}),
-                jasmine.objectContaining({'_name': "Impaler chainglaive"}),
-                jasmine.objectContaining({'_name': "Mechatendrils"}),
-                jasmine.objectContaining({'_name': "Techno-virus injector"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Lord Discordant"}),
-                jasmine.objectContaining({'_name': "Lord Discordant1"}),
-                jasmine.objectContaining({'_name': "Lord Discordant2"}),
-                jasmine.objectContaining({'_name': "Lord Discordant3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Sorcerer",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Sorcerer"}),
-              ],
-              '_modelList': [
-                "Sorcerer (Bolt pistol, Force sword, Frag & Krak grenades, No Chaos Mark, Smite)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Force sword"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Sorcerer"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Chaos Cultists",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Chaos Cultist"}),
-                jasmine.objectContaining({'_name': "Cultist Champion"}),
-              ],
-              '_modelList': [
-                "9x Chaos Cultist w/ Autogun (Autogun)",
-                "Cultist Champion (Autogun)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Autogun"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Chaos Space Marines",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Aspiring Champion"}),
-                jasmine.objectContaining({'_name': "Chaos Space Marine"}),
-              ],
-              '_modelList': [
-                "Aspiring Champion (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Chaos Space Marines",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Aspiring Champion"}),
-                jasmine.objectContaining({'_name': "Chaos Space Marine"}),
-              ],
-              '_modelList': [
-                "Aspiring Champion (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Chaos Terminators",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Chaos Terminator"}),
-                jasmine.objectContaining({'_name': "Chaos Terminator Champion"}),
-              ],
-              '_modelList': [
-                "Chaos Terminator Champion (Combi-bolter, Chainaxe)",
-                "4x Terminator (Combi-bolter, Chainaxe)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Combi-bolter"}),
-                jasmine.objectContaining({'_name': "Chainaxe"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Mutilators",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Mutilator"}),
-              ],
-              '_modelList': [
-                "3x Mutilator (Fleshmetal weapons)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fleshmetal weapons"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Plague Marines",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Plague Champion"}),
-                jasmine.objectContaining({'_name': "Plague Marine"}),
-              ],
-              '_modelList': [
-                "Plague Champion (Boltgun, Plague knife, Blight Grenades, Krak grenades)",
-                "4x Plague Marine w/ boltgun (Boltgun, Plague knife, Blight Grenades, Krak Grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Plague knife"}),
-                jasmine.objectContaining({'_name': "Blight Grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Possessed",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Possessed"}),
-              ],
-              '_modelList': [
-                "5x Possessed (Horrifying Mutations)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Horrifying Mutations"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Chaos Spawn",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Chaos Spawn"}),
-              ],
-              '_modelList': [
-                "Chaos Spawn (Hideous mutations)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Hideous mutations"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Obliterators",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Obliterator"}),
-              ],
-              '_modelList': [
-                "Obliterator (Fleshmetal guns, Crushing fists)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fleshmetal guns"}),
-                jasmine.objectContaining({'_name': "Crushing fists"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Heldrake",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Heldrake"}),
-              ],
-              '_modelList': [
-                "Heldrake (Hades Autocannon, Heldrake claws, No Chaos Mark)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Hades autocannon"}),
-                jasmine.objectContaining({'_name': "Heldrake claws"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Heldrake"}),
-                jasmine.objectContaining({'_name': "Heldrake1"}),
-                jasmine.objectContaining({'_name': "Heldrake2"}),
-                jasmine.objectContaining({'_name': "Heldrake3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Battle-forged CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Detachment CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Legion",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Fateskimmer",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Fateskimmer"}),
-              ],
-              '_modelList': [
-                "Fateskimmer (Lamprey bite, Ritual dagger, Smite)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Lamprey bite"}),
-                jasmine.objectContaining({'_name': "Ritual dagger"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Psyker"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Kairos Fateweaver",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Kairos Fateweaver"}),
-              ],
-              '_modelList': [
-                "Kairos Fateweaver (Staff of Tomorrow, Bolt of Change, Boon of Change, Flickering Flames, Gaze of Fate, Infernal Gateway, Smite, Treason of Tzeentch)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Staff of Tomorrow"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-                jasmine.objectContaining({'_name': "Bolt of Change"}),
-                jasmine.objectContaining({'_name': "Boon of Change"}),
-                jasmine.objectContaining({'_name': "Flickering Flames"}),
-                jasmine.objectContaining({'_name': "Gaze of Fate"}),
-                jasmine.objectContaining({'_name': "Infernal Gateway"}),
-                jasmine.objectContaining({'_name': "Treason of Tzeentch"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Psyker"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Kairos Fateweaver"}),
-                jasmine.objectContaining({'_name': "Kairos Fateweaver1"}),
-                jasmine.objectContaining({'_name': "Kairos Fateweaver2"}),
-                jasmine.objectContaining({'_name': "Kairos Fateweaver3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Bloodletters",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Bloodletter"}),
-                jasmine.objectContaining({'_name': "Bloodreaper"}),
-              ],
-              '_modelList': [
-                "9x Bloodletter (Hellblade)",
-                "Bloodreaper (Hellblade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Hellblade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Daemonettes",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Alluress"}),
-                jasmine.objectContaining({'_name': "Daemonette"}),
-              ],
-              '_modelList': [
-                "Alluress (Piercing claws)",
-                "9x Daemonette (Piercing claws)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Piercing claws"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Nurglings",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Nurgling Swarm"}),
-              ],
-              '_modelList': [
-                "3x Nurgling Swarms (Diseased claws and teeth)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Diseased claws and teeth"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Exalted Flamer",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Exalted Flamer"}),
-              ],
-              '_modelList': [
-                "Exalted Flamer (Fire of Tzeentch, Tongues of flame)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fire of Tzeentch (Blue)"}),
-                jasmine.objectContaining({'_name': "Fire of Tzeentch (Pink)"}),
-                jasmine.objectContaining({'_name': "Tongues of flame"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Seekers",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Heartseeker"}),
-                jasmine.objectContaining({'_name': "Seeker"}),
-              ],
-              '_modelList': [
-                "Heartseeker (Lashing tongue, Piercing claws)",
-                "4x Seeker (Lashing tongue, Piercing claws)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Lashing tongue"}),
-                jasmine.objectContaining({'_name': "Piercing claws"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Seeker Chariot",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Seeker Chariot"}),
-              ],
-              '_modelList': [
-                "Seeker Chariot (2x Lashes of Torment, Lashing tongues, 2x Piercing claws)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Lashes of Torment"}),
-                jasmine.objectContaining({'_name': "Lashing tongues"}),
-                jasmine.objectContaining({'_name': "Piercing claws"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Chaos Allegiance",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Detachment CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Daemon Prince",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Daemon Prince"}),
+                ],
+                '_modelList': [
+                  "Daemon Prince (Hellforged sword, Malefic talon)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Hellforged sword"}),
+                  jasmine.objectContaining({'_name': "Malefic talon"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Lord Discordant on Helstalker",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Lord Discordant on Helstalker"}),
+                ],
+                '_modelList': [
+                  "Lord Discordant on Helstalker (Autocannon, Bolt pistol, Bladed limbs and tail, Impaler chainglaive, Mechatendrils, Techno-virus injector, Frag & Krak grenades, 4. Hatred Incarnate, Intoxicating Elixir, Mark of Slaanesh, Warlord)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Autocannon"}),
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Bladed limbs and tail"}),
+                  jasmine.objectContaining({'_name': "Impaler chainglaive"}),
+                  jasmine.objectContaining({'_name': "Mechatendrils"}),
+                  jasmine.objectContaining({'_name': "Techno-virus injector"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Lord Discordant"}),
+                  jasmine.objectContaining({'_name': "Lord Discordant1"}),
+                  jasmine.objectContaining({'_name': "Lord Discordant2"}),
+                  jasmine.objectContaining({'_name': "Lord Discordant3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Sorcerer",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Sorcerer"}),
+                ],
+                '_modelList': [
+                  "Sorcerer (Bolt pistol, Force sword, Frag & Krak grenades, No Chaos Mark, Smite)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Force sword"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Sorcerer"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Chaos Cultists",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Chaos Cultist"}),
+                  jasmine.objectContaining({'_name': "Cultist Champion"}),
+                ],
+                '_modelList': [
+                  "9x Chaos Cultist w/ Autogun (Autogun)",
+                  "Cultist Champion (Autogun)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Autogun"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Chaos Space Marines",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Aspiring Champion"}),
+                  jasmine.objectContaining({'_name': "Chaos Space Marine"}),
+                ],
+                '_modelList': [
+                  "Aspiring Champion (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Chaos Space Marines",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Aspiring Champion"}),
+                  jasmine.objectContaining({'_name': "Chaos Space Marine"}),
+                ],
+                '_modelList': [
+                  "Aspiring Champion (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Chaos Terminators",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Chaos Terminator"}),
+                  jasmine.objectContaining({'_name': "Chaos Terminator Champion"}),
+                ],
+                '_modelList': [
+                  "Chaos Terminator Champion (Combi-bolter, Chainaxe)",
+                  "4x Terminator (Combi-bolter, Chainaxe)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Combi-bolter"}),
+                  jasmine.objectContaining({'_name': "Chainaxe"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Mutilators",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Mutilator"}),
+                ],
+                '_modelList': [
+                  "3x Mutilator (Fleshmetal weapons)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fleshmetal weapons"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Plague Marines",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Plague Champion"}),
+                  jasmine.objectContaining({'_name': "Plague Marine"}),
+                ],
+                '_modelList': [
+                  "Plague Champion (Boltgun, Plague knife, Blight Grenades, Krak grenades)",
+                  "4x Plague Marine w/ boltgun (Boltgun, Plague knife, Blight Grenades, Krak Grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Plague knife"}),
+                  jasmine.objectContaining({'_name': "Blight Grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Possessed",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Possessed"}),
+                ],
+                '_modelList': [
+                  "5x Possessed (Horrifying Mutations)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Horrifying Mutations"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Chaos Spawn",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Chaos Spawn"}),
+                ],
+                '_modelList': [
+                  "Chaos Spawn (Hideous mutations)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Hideous mutations"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Obliterators",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Obliterator"}),
+                ],
+                '_modelList': [
+                  "Obliterator (Fleshmetal guns, Crushing fists)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fleshmetal guns"}),
+                  jasmine.objectContaining({'_name': "Crushing fists"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Heldrake",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Heldrake"}),
+                ],
+                '_modelList': [
+                  "Heldrake (Hades Autocannon, Heldrake claws, No Chaos Mark)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Hades autocannon"}),
+                  jasmine.objectContaining({'_name': "Heldrake claws"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Heldrake"}),
+                  jasmine.objectContaining({'_name': "Heldrake1"}),
+                  jasmine.objectContaining({'_name': "Heldrake2"}),
+                  jasmine.objectContaining({'_name': "Heldrake3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Battle-forged CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Detachment CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Legion",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Fateskimmer",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Fateskimmer"}),
+                ],
+                '_modelList': [
+                  "Fateskimmer (Lamprey bite, Ritual dagger, Smite)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Lamprey bite"}),
+                  jasmine.objectContaining({'_name': "Ritual dagger"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Psyker"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Kairos Fateweaver",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Kairos Fateweaver"}),
+                ],
+                '_modelList': [
+                  "Kairos Fateweaver (Staff of Tomorrow, Bolt of Change, Boon of Change, Flickering Flames, Gaze of Fate, Infernal Gateway, Smite, Treason of Tzeentch)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Staff of Tomorrow"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                  jasmine.objectContaining({'_name': "Bolt of Change"}),
+                  jasmine.objectContaining({'_name': "Boon of Change"}),
+                  jasmine.objectContaining({'_name': "Flickering Flames"}),
+                  jasmine.objectContaining({'_name': "Gaze of Fate"}),
+                  jasmine.objectContaining({'_name': "Infernal Gateway"}),
+                  jasmine.objectContaining({'_name': "Treason of Tzeentch"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Psyker"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Kairos Fateweaver"}),
+                  jasmine.objectContaining({'_name': "Kairos Fateweaver1"}),
+                  jasmine.objectContaining({'_name': "Kairos Fateweaver2"}),
+                  jasmine.objectContaining({'_name': "Kairos Fateweaver3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Bloodletters",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Bloodletter"}),
+                  jasmine.objectContaining({'_name': "Bloodreaper"}),
+                ],
+                '_modelList': [
+                  "9x Bloodletter (Hellblade)",
+                  "Bloodreaper (Hellblade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Hellblade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Daemonettes",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Alluress"}),
+                  jasmine.objectContaining({'_name': "Daemonette"}),
+                ],
+                '_modelList': [
+                  "Alluress (Piercing claws)",
+                  "9x Daemonette (Piercing claws)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Piercing claws"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Nurglings",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Nurgling Swarm"}),
+                ],
+                '_modelList': [
+                  "3x Nurgling Swarms (Diseased claws and teeth)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Diseased claws and teeth"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Exalted Flamer",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Exalted Flamer"}),
+                ],
+                '_modelList': [
+                  "Exalted Flamer (Fire of Tzeentch, Tongues of flame)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fire of Tzeentch (Blue)"}),
+                  jasmine.objectContaining({'_name': "Fire of Tzeentch (Pink)"}),
+                  jasmine.objectContaining({'_name': "Tongues of flame"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Seekers",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Heartseeker"}),
+                  jasmine.objectContaining({'_name': "Seeker"}),
+                ],
+                '_modelList': [
+                  "Heartseeker (Lashing tongue, Piercing claws)",
+                  "4x Seeker (Lashing tongue, Piercing claws)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Lashing tongue"}),
+                  jasmine.objectContaining({'_name': "Piercing claws"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Seeker Chariot",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Seeker Chariot"}),
+                ],
+                '_modelList': [
+                  "Seeker Chariot (2x Lashes of Torment, Lashing tongues, 2x Piercing claws)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Lashes of Torment"}),
+                  jasmine.objectContaining({'_name': "Lashing tongues"}),
+                  jasmine.objectContaining({'_name': "Piercing claws"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Chaos Allegiance",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Detachment CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/DrukariTestSpec.ts
+++ b/spec/DrukariTestSpec.ts
@@ -12,355 +12,368 @@ describe("Create40kRoster", function() {
         '_points': 2068,
         '_commandPoints': 13,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Archon",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Archon"}),
-              ],
-              '_modelList': [
-                "Archon (Splinter pistol, Huskblade, Shadowfield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter pistol"}),
-                jasmine.objectContaining({'_name': "Huskblade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Haemonculus",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Haemonculus"}),
-              ],
-              '_modelList': [
-                "Haemonculus (Splinter pistol, Agoniser)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter pistol"}),
-                jasmine.objectContaining({'_name': "Agoniser"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Kabalite Warriors",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Kabalite Warrior"}),
-                jasmine.objectContaining({'_name': "Sybarite"}),
-              ],
-              '_modelList': [
-                "4x Kabalite Warrior (Splinter Rifle)",
-                "Sybarite (Splinter Rifle)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter rifle"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Wracks",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Acothyst"}),
-                jasmine.objectContaining({'_name': "Wracks"}),
-              ],
-              '_modelList': [
-                "Acothyst (Haemonculus tools)",
-                "4x Wracks (Haemonculus Tools)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Haemonculus tools"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Wyches",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Hekatrix"}),
-                jasmine.objectContaining({'_name': "Wych"}),
-              ],
-              '_modelList': [
-                "Hekatrix (Splinter pistol, Hekatarii blade, Plasma Grenade)",
-                "4x Wych (Splinter Pistol, Hekatarii blade, Plasma Grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter pistol"}),
-                jasmine.objectContaining({'_name': "Hekatarii blade"}),
-                jasmine.objectContaining({'_name': "Plasma Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Grotesques",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Grotesque"}),
-              ],
-              '_modelList': [
-                "3x Grotesque with Monstrous Cleaver (Flesh gauntlet, Monstrous cleaver)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Flesh Gauntlet"}),
-                jasmine.objectContaining({'_name': "Monstrous cleaver"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Hellions",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Helliarch"}),
-                jasmine.objectContaining({'_name': "Hellion"}),
-              ],
-              '_modelList': [
-                "Helliarch (Splinter pods, Hellglaive)",
-                "4x Hellion (Splinter pods, Hellglaive)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter pods"}),
-                jasmine.objectContaining({'_name': "Hellglaive"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Reavers",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Arena Champion"}),
-                jasmine.objectContaining({'_name': "Reaver"}),
-              ],
-              '_modelList': [
-                "Arena Champion (Splinter pistol, Bladevanes, Splinter Rifle)",
-                "2x Reaver (Splinter pistol, Splinter rifle, Bladevanes)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter pistol"}),
-                jasmine.objectContaining({'_name': "Splinter rifle"}),
-                jasmine.objectContaining({'_name': "Bladevanes"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Scourges",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Scourge"}),
-                jasmine.objectContaining({'_name': "Solarite"}),
-              ],
-              '_modelList': [
-                "4x Scourge w/ shardcarbine (Shardcarbine, Plasma Grenade)",
-                "Solarite (Shardcarbine, Plasma Grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shardcarbine"}),
-                jasmine.objectContaining({'_name': "Plasma Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Ravager",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Ravager"}),
-              ],
-              '_modelList': [
-                "Ravager (3x Dark Lance, Bladevanes, Night Shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Dark Lance"}),
-                jasmine.objectContaining({'_name': "Bladevanes"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Ravager"}),
-                jasmine.objectContaining({'_name': "Ravager 1"}),
-                jasmine.objectContaining({'_name': "Ravager 3"}),
-                jasmine.objectContaining({'_name': "Ravager 2"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Reaper",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Reaper"}),
-              ],
-              '_modelList': [
-                "Reaper (Storm Vortex Projector, Scythevanes, Sharpened prow blade, Night Shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Storm Vortex Projector - Beam"}),
-                jasmine.objectContaining({'_name': "Storm Vortex Projector - Blast"}),
-                jasmine.objectContaining({'_name': "Scythevanes"}),
-                jasmine.objectContaining({'_name': "Sharpened prow blade"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Reaper"}),
-                jasmine.objectContaining({'_name': "Reaper 1"}),
-                jasmine.objectContaining({'_name': "Reaper 2"}),
-                jasmine.objectContaining({'_name': "Reaper 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Voidraven",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Voidraven"}),
-              ],
-              '_modelList': [
-                "Voidraven (Two void lances, Night Shield, Void Mine)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Void lance"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Voidraven 1"}),
-                jasmine.objectContaining({'_name': "Voidraven"}),
-                jasmine.objectContaining({'_name': "Voidraven 3"}),
-                jasmine.objectContaining({'_name': "Voidraven 2"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Raider",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Raider"}),
-              ],
-              '_modelList': [
-                "Raider (Dark Lance, Bladevanes, Night Shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Dark Lance"}),
-                jasmine.objectContaining({'_name': "Bladevanes"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Raider 3"}),
-                jasmine.objectContaining({'_name': "Raider 2"}),
-                jasmine.objectContaining({'_name': "Raider 1"}),
-                jasmine.objectContaining({'_name': "Raider"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Venom",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Venom"}),
-              ],
-              '_modelList': [
-                "Venom (Splinter Cannon, Twin splinter rifle, Bladevanes, Flickerfield, Night Shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Splinter Cannon"}),
-                jasmine.objectContaining({'_name': "Twin splinter rifle"}),
-                jasmine.objectContaining({'_name': "Bladevanes"}),
-              ]}),
-          ]}),
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Shadowseer",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Shadowseer"}),
-              ],
-              '_modelList': [
-                "Shadowseer (Hallucinogen Grenade Launcher, Shuriken Pistol, Miststave, Smite)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Hallucinogen Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Shuriken Pistol"}),
-                jasmine.objectContaining({'_name': "Miststave"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Shadowseer - Psyker"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "The Yncarne",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "The Yncarne"}),
-              ],
-              '_modelList': [
-                "The Yncarne (Vilith-zhar, the Sword of Souls)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Vilith-zhar, the Sword of Souls"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Psyker"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Yvraine",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Yvraine"}),
-              ],
-              '_modelList': [
-                "Yvraine (Kha-vir, the Sword of Sorrows.)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Kha-vir, the Sword of Sorrows."}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Psyker"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Troupe",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Player"}),
-              ],
-              '_modelList': [
-                "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shuriken Pistol"}),
-                jasmine.objectContaining({'_name': "Harlequin's Blade"}),
-                jasmine.objectContaining({'_name': "Plasma Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Troupe",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Player"}),
-              ],
-              '_modelList': [
-                "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shuriken Pistol"}),
-                jasmine.objectContaining({'_name': "Harlequin's Blade"}),
-                jasmine.objectContaining({'_name': "Plasma Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Troupe",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Player"}),
-              ],
-              '_modelList': [
-                "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shuriken Pistol"}),
-                jasmine.objectContaining({'_name': "Harlequin's Blade"}),
-                jasmine.objectContaining({'_name': "Plasma Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Death Jester",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Death Jester"}),
-              ],
-              '_modelList': [
-                "Death Jester (Shrieker Cannon)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shrieker Cannon (Shrieker)"}),
-                jasmine.objectContaining({'_name': "Shrieker Cannon (Shuriken)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Skyweavers",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Skyweaver"}),
-              ],
-              '_modelList': [
-                "2x Skyweaver (Shuriken Cannon, Star Bolas)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shuriken Cannon"}),
-                jasmine.objectContaining({'_name': "Star Bolas"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Voidweaver",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Voidweaver"}),
-              ],
-              '_modelList': [
-                "Voidweaver (Haywire Cannon, 2x Shuriken Cannon)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Haywire Cannon"}),
-                jasmine.objectContaining({'_name': "Shuriken Cannon"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Starweaver",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Starweaver"}),
-              ],
-              '_modelList': [
-                "Starweaver (2x Shuriken Cannon)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shuriken Cannon"}),
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [
+              "Detachment Type: Mixed Detachment",
+              "Detachment CP",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Archon",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Archon"}),
+                ],
+                '_modelList': [
+                  "Archon (Splinter pistol, Huskblade, Shadowfield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter pistol"}),
+                  jasmine.objectContaining({'_name': "Huskblade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Haemonculus",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Haemonculus"}),
+                ],
+                '_modelList': [
+                  "Haemonculus (Splinter pistol, Agoniser)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter pistol"}),
+                  jasmine.objectContaining({'_name': "Agoniser"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Kabalite Warriors",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Kabalite Warrior"}),
+                  jasmine.objectContaining({'_name': "Sybarite"}),
+                ],
+                '_modelList': [
+                  "4x Kabalite Warrior (Splinter Rifle)",
+                  "Sybarite (Splinter Rifle)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter rifle"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Wracks",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Acothyst"}),
+                  jasmine.objectContaining({'_name': "Wracks"}),
+                ],
+                '_modelList': [
+                  "Acothyst (Haemonculus tools)",
+                  "4x Wracks (Haemonculus Tools)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Haemonculus tools"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Wyches",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Hekatrix"}),
+                  jasmine.objectContaining({'_name': "Wych"}),
+                ],
+                '_modelList': [
+                  "Hekatrix (Splinter pistol, Hekatarii blade, Plasma Grenade)",
+                  "4x Wych (Splinter Pistol, Hekatarii blade, Plasma Grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter pistol"}),
+                  jasmine.objectContaining({'_name': "Hekatarii blade"}),
+                  jasmine.objectContaining({'_name': "Plasma Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Grotesques",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Grotesque"}),
+                ],
+                '_modelList': [
+                  "3x Grotesque with Monstrous Cleaver (Flesh gauntlet, Monstrous cleaver)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Flesh Gauntlet"}),
+                  jasmine.objectContaining({'_name': "Monstrous cleaver"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Hellions",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Helliarch"}),
+                  jasmine.objectContaining({'_name': "Hellion"}),
+                ],
+                '_modelList': [
+                  "Helliarch (Splinter pods, Hellglaive)",
+                  "4x Hellion (Splinter pods, Hellglaive)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter pods"}),
+                  jasmine.objectContaining({'_name': "Hellglaive"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Reavers",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Arena Champion"}),
+                  jasmine.objectContaining({'_name': "Reaver"}),
+                ],
+                '_modelList': [
+                  "Arena Champion (Splinter pistol, Bladevanes, Splinter Rifle)",
+                  "2x Reaver (Splinter pistol, Splinter rifle, Bladevanes)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter pistol"}),
+                  jasmine.objectContaining({'_name': "Splinter rifle"}),
+                  jasmine.objectContaining({'_name': "Bladevanes"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Scourges",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Scourge"}),
+                  jasmine.objectContaining({'_name': "Solarite"}),
+                ],
+                '_modelList': [
+                  "4x Scourge w/ shardcarbine (Shardcarbine, Plasma Grenade)",
+                  "Solarite (Shardcarbine, Plasma Grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shardcarbine"}),
+                  jasmine.objectContaining({'_name': "Plasma Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Ravager",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Ravager"}),
+                ],
+                '_modelList': [
+                  "Ravager (3x Dark Lance, Bladevanes, Night Shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Dark Lance"}),
+                  jasmine.objectContaining({'_name': "Bladevanes"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Ravager"}),
+                  jasmine.objectContaining({'_name': "Ravager 1"}),
+                  jasmine.objectContaining({'_name': "Ravager 3"}),
+                  jasmine.objectContaining({'_name': "Ravager 2"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Reaper",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Reaper"}),
+                ],
+                '_modelList': [
+                  "Reaper (Storm Vortex Projector, Scythevanes, Sharpened prow blade, Night Shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Storm Vortex Projector - Beam"}),
+                  jasmine.objectContaining({'_name': "Storm Vortex Projector - Blast"}),
+                  jasmine.objectContaining({'_name': "Scythevanes"}),
+                  jasmine.objectContaining({'_name': "Sharpened prow blade"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Reaper"}),
+                  jasmine.objectContaining({'_name': "Reaper 1"}),
+                  jasmine.objectContaining({'_name': "Reaper 2"}),
+                  jasmine.objectContaining({'_name': "Reaper 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Voidraven",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Voidraven"}),
+                ],
+                '_modelList': [
+                  "Voidraven (Two void lances, Night Shield, Void Mine)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Void lance"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Voidraven 1"}),
+                  jasmine.objectContaining({'_name': "Voidraven"}),
+                  jasmine.objectContaining({'_name': "Voidraven 3"}),
+                  jasmine.objectContaining({'_name': "Voidraven 2"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Raider",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Raider"}),
+                ],
+                '_modelList': [
+                  "Raider (Dark Lance, Bladevanes, Night Shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Dark Lance"}),
+                  jasmine.objectContaining({'_name': "Bladevanes"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Raider 3"}),
+                  jasmine.objectContaining({'_name': "Raider 2"}),
+                  jasmine.objectContaining({'_name': "Raider 1"}),
+                  jasmine.objectContaining({'_name': "Raider"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Venom",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Venom"}),
+                ],
+                '_modelList': [
+                  "Venom (Splinter Cannon, Twin splinter rifle, Bladevanes, Flickerfield, Night Shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Splinter Cannon"}),
+                  jasmine.objectContaining({'_name': "Twin splinter rifle"}),
+                  jasmine.objectContaining({'_name': "Bladevanes"}),
+                ]}),
+            ]
+          }),
+          jasmine.objectContaining({
+            '_configurations': [
+              "Masque Form: The Silent Shroud: Dance of Nightmares Made Flesh",
+              "Battle-forged CP",
+              "Detachment CP",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Shadowseer",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Shadowseer"}),
+                ],
+                '_modelList': [
+                  "Shadowseer (Hallucinogen Grenade Launcher, Shuriken Pistol, Miststave, Smite)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Hallucinogen Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Shuriken Pistol"}),
+                  jasmine.objectContaining({'_name': "Miststave"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Shadowseer - Psyker"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "The Yncarne",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "The Yncarne"}),
+                ],
+                '_modelList': [
+                  "The Yncarne (Vilith-zhar, the Sword of Souls)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Vilith-zhar, the Sword of Souls"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Psyker"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Yvraine",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Yvraine"}),
+                ],
+                '_modelList': [
+                  "Yvraine (Kha-vir, the Sword of Sorrows.)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Kha-vir, the Sword of Sorrows."}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Psyker"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Troupe",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Player"}),
+                ],
+                '_modelList': [
+                  "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shuriken Pistol"}),
+                  jasmine.objectContaining({'_name': "Harlequin's Blade"}),
+                  jasmine.objectContaining({'_name': "Plasma Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Troupe",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Player"}),
+                ],
+                '_modelList': [
+                  "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shuriken Pistol"}),
+                  jasmine.objectContaining({'_name': "Harlequin's Blade"}),
+                  jasmine.objectContaining({'_name': "Plasma Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Troupe",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Player"}),
+                ],
+                '_modelList': [
+                  "5x Player (Shuriken Pistol, Harlequin's Blade, Plasma Grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shuriken Pistol"}),
+                  jasmine.objectContaining({'_name': "Harlequin's Blade"}),
+                  jasmine.objectContaining({'_name': "Plasma Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Death Jester",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Death Jester"}),
+                ],
+                '_modelList': [
+                  "Death Jester (Shrieker Cannon)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shrieker Cannon (Shrieker)"}),
+                  jasmine.objectContaining({'_name': "Shrieker Cannon (Shuriken)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Skyweavers",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Skyweaver"}),
+                ],
+                '_modelList': [
+                  "2x Skyweaver (Shuriken Cannon, Star Bolas)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shuriken Cannon"}),
+                  jasmine.objectContaining({'_name': "Star Bolas"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Voidweaver",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Voidweaver"}),
+                ],
+                '_modelList': [
+                  "Voidweaver (Haywire Cannon, 2x Shuriken Cannon)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Haywire Cannon"}),
+                  jasmine.objectContaining({'_name': "Shuriken Cannon"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Starweaver",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Starweaver"}),
+                ],
+                '_modelList': [
+                  "Starweaver (2x Shuriken Cannon)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shuriken Cannon"}),
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/GuardSpec.ts
+++ b/spec/GuardSpec.ts
@@ -12,306 +12,309 @@ describe("Create40kRoster", function() {
         '_points': 1625,
         '_commandPoints': 0,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Commissar Yarrick",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Commissar Yarrick"}),
-              ],
-              '_modelList': [
-                "Commissar Yarrick (Bale Eye, Bolt pistol, Storm bolter, Power Klaw, Master of Command, Warlord)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bale Eye"}),
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-                jasmine.objectContaining({'_name': "Power Klaw"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Knight Commander Pask",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Knight Commander Pask"}),
-              ],
-              '_modelList': [
-                "Knight Commander Pask (Battle Cannon, Heavy Bolter, Stat Damage (Pask))"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Battle Cannon"}),
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Pask Russ 1"}),
-                jasmine.objectContaining({'_name': "Pask Russ 2"}),
-                jasmine.objectContaining({'_name': "Pask Russ 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Sly Marbo",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Sly Marbo"}),
-              ],
-              '_modelList': [
-                "Sly Marbo (Ripper Pistol, Envenomed Blade, Frag Grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Ripper Pistol"}),
-                jasmine.objectContaining({'_name': "Envenomed Blade"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Conscripts",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Conscript"}),
-              ],
-              '_modelList': [
-                "20x Conscript (Lasgun, Frag grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Lasgun"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Infantry Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Guardsman"}),
-                jasmine.objectContaining({'_name': "Sergeant"}),
-              ],
-              '_modelList': [
-                "9x Guardsman (Lasgun, Frag grenade)",
-                "Sergeant (Laspistol, Frag grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Lasgun"}),
-                jasmine.objectContaining({'_name': "Laspistol"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Infantry Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Guardsman"}),
-                jasmine.objectContaining({'_name': "Sergeant"}),
-              ],
-              '_modelList': [
-                "9x Guardsman (Lasgun, Frag grenade)",
-                "Sergeant (Laspistol, Frag grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Lasgun"}),
-                jasmine.objectContaining({'_name': "Laspistol"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Infantry Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Guardsman"}),
-                jasmine.objectContaining({'_name': "Sergeant"}),
-              ],
-              '_modelList': [
-                "9x Guardsman (Lasgun, Frag grenade)",
-                "Sergeant (Laspistol, Frag grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Lasgun"}),
-                jasmine.objectContaining({'_name': "Laspistol"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Infantry Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Guardsman"}),
-                jasmine.objectContaining({'_name': "Sergeant"}),
-              ],
-              '_modelList': [
-                "9x Guardsman (Lasgun, Frag grenade)",
-                "Sergeant (Laspistol, Frag grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Lasgun"}),
-                jasmine.objectContaining({'_name': "Laspistol"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Militarum Tempestus Scions",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Tempestor"}),
-                jasmine.objectContaining({'_name': "Tempestus Scion"}),
-              ],
-              '_modelList': [
-                "4x Scion (Hot-shot Lasgun, Frag & Krak grenades)",
-                "Scion w/ Special Weapon (Grenade Launcher, Frag & Krak grenades)",
-                "Scion w/ Vox-caster (Hot-Shot Lasgun, Hot-shot Laspistol, Vox-caster)",
-                "Tempestor (Hot-shot Laspistol, Power fist, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Grenade Launcher (Frag)"}),
-                jasmine.objectContaining({'_name': "Grenade Launcher (Krak)"}),
-                jasmine.objectContaining({'_name': "Hot-shot Lasgun"}),
-                jasmine.objectContaining({'_name': "Hot-shot Laspistol"}),
-                jasmine.objectContaining({'_name': "Power fist"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Bullgryns",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Bullgryn"}),
-                jasmine.objectContaining({'_name': "Bullgryn Bone 'ead"}),
-              ],
-              '_modelList': [
-                "2x Bullgryn (Grenadier Gauntlet, Frag Bombs, Slabshield)",
-                "Bullgryn Bone 'ead (Grenadier Gauntlet, Frag Bombs, Slabshield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Grenadier Gauntlet"}),
-                jasmine.objectContaining({'_name': "Frag Bombs"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Hades Breaching Drill Squadron",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Hades Breaching Drill"}),
-                jasmine.objectContaining({'_name': "Veteran"}),
-                jasmine.objectContaining({'_name': "Veteran Sergeant"}),
-              ],
-              '_modelList': [
-                "Hades Breaching Drill (Melta Cutter Drill)",
-                "Veteran Sergeant (Laspistol, Chainsword, Frag Grenades)",
-                "9x Veteran w/ Shotgun (Shotgun, Frag Grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Laspistol"}),
-                jasmine.objectContaining({'_name': "Shotgun"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Melta Cutter Drill"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Special Weapons Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Guardsman"}),
-              ],
-              '_modelList': [
-                "3x Guardsman (Lasgun, Frag grenade)",
-                "Guardsman W/ Special Weapon (Grenade Launcher, Frag grenade)",
-                "Guardsman W/ Special Weapon (Meltagun, Frag grenade)",
-                "Guardsman W/ Special Weapon (Sniper rifle, Frag grenade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Grenade Launcher (Frag)"}),
-                jasmine.objectContaining({'_name': "Grenade Launcher (Krak)"}),
-                jasmine.objectContaining({'_name': "Lasgun"}),
-                jasmine.objectContaining({'_name': "Meltagun"}),
-                jasmine.objectContaining({'_name': "Sniper rifle"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Hellhounds",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Hellhound"}),
-              ],
-              '_modelList': [
-                "Bane Wolf (Turret-mounted Chem Cannon, Heavy Bolter, Stat Damage (HS))",
-                "Devil Dog (Heavy Bolter, Turret-mounted Melta Cannon, Stat Damage (HS))",
-                "Hellhound (Heavy Bolter, Turret-mounted Inferno Cannon, Stat Damage (HS))"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Chem Cannon"}),
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-                jasmine.objectContaining({'_name': "Inferno Cannon"}),
-                jasmine.objectContaining({'_name': "Melta Cannon"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Scout Sentinels",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Scout Sentinel"}),
-              ],
-              '_modelList': [
-                "Scout Sentinel (Multi-laser)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Multi-laser"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tauros Venator",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Tauros"}),
-              ],
-              '_modelList': [
-                "Tauros (Twin Multi-Laser)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Twin Multi-Laser"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Hydras",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Hydra"}),
-              ],
-              '_modelList': [
-                "Hydra (Heavy Bolter, Hydra Quad Autocannon, Stat Damage (HS))"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-                jasmine.objectContaining({'_name': "Hydra Quad Autocannon"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Rapier Laser Destroyer",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Guardsmen Crew"}),
-                jasmine.objectContaining({'_name': "Rapier"}),
-              ],
-              '_modelList': [
-                "2x Guardsmen Crew (Lasgun, Frag Grenades)",
-                "Rapier (Laser Destroyer)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Laser Destroyer"}),
-                jasmine.objectContaining({'_name': "Lasgun"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Wyverns",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Wyvern"}),
-              ],
-              '_modelList': [
-                "Wyvern (Heavy Bolter, Wyven Quad Stormshard Mortar)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-                jasmine.objectContaining({'_name': "Wyvern Quad Stormshard Mortar"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
-                jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Regimental Doctrine",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Commissar Yarrick",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Commissar Yarrick"}),
+                ],
+                '_modelList': [
+                  "Commissar Yarrick (Bale Eye, Bolt pistol, Storm bolter, Power Klaw, Master of Command, Warlord)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bale Eye"}),
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                  jasmine.objectContaining({'_name': "Power Klaw"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Knight Commander Pask",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Knight Commander Pask"}),
+                ],
+                '_modelList': [
+                  "Knight Commander Pask (Battle Cannon, Heavy Bolter, Stat Damage (Pask))"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Battle Cannon"}),
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Pask Russ 1"}),
+                  jasmine.objectContaining({'_name': "Pask Russ 2"}),
+                  jasmine.objectContaining({'_name': "Pask Russ 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Sly Marbo",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Sly Marbo"}),
+                ],
+                '_modelList': [
+                  "Sly Marbo (Ripper Pistol, Envenomed Blade, Frag Grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Ripper Pistol"}),
+                  jasmine.objectContaining({'_name': "Envenomed Blade"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Conscripts",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Conscript"}),
+                ],
+                '_modelList': [
+                  "20x Conscript (Lasgun, Frag grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Lasgun"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Infantry Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Guardsman"}),
+                  jasmine.objectContaining({'_name': "Sergeant"}),
+                ],
+                '_modelList': [
+                  "9x Guardsman (Lasgun, Frag grenade)",
+                  "Sergeant (Laspistol, Frag grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Lasgun"}),
+                  jasmine.objectContaining({'_name': "Laspistol"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Infantry Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Guardsman"}),
+                  jasmine.objectContaining({'_name': "Sergeant"}),
+                ],
+                '_modelList': [
+                  "9x Guardsman (Lasgun, Frag grenade)",
+                  "Sergeant (Laspistol, Frag grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Lasgun"}),
+                  jasmine.objectContaining({'_name': "Laspistol"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Infantry Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Guardsman"}),
+                  jasmine.objectContaining({'_name': "Sergeant"}),
+                ],
+                '_modelList': [
+                  "9x Guardsman (Lasgun, Frag grenade)",
+                  "Sergeant (Laspistol, Frag grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Lasgun"}),
+                  jasmine.objectContaining({'_name': "Laspistol"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Infantry Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Guardsman"}),
+                  jasmine.objectContaining({'_name': "Sergeant"}),
+                ],
+                '_modelList': [
+                  "9x Guardsman (Lasgun, Frag grenade)",
+                  "Sergeant (Laspistol, Frag grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Lasgun"}),
+                  jasmine.objectContaining({'_name': "Laspistol"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Militarum Tempestus Scions",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Tempestor"}),
+                  jasmine.objectContaining({'_name': "Tempestus Scion"}),
+                ],
+                '_modelList': [
+                  "4x Scion (Hot-shot Lasgun, Frag & Krak grenades)",
+                  "Scion w/ Special Weapon (Grenade Launcher, Frag & Krak grenades)",
+                  "Scion w/ Vox-caster (Hot-Shot Lasgun, Hot-shot Laspistol, Vox-caster)",
+                  "Tempestor (Hot-shot Laspistol, Power fist, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Grenade Launcher (Frag)"}),
+                  jasmine.objectContaining({'_name': "Grenade Launcher (Krak)"}),
+                  jasmine.objectContaining({'_name': "Hot-shot Lasgun"}),
+                  jasmine.objectContaining({'_name': "Hot-shot Laspistol"}),
+                  jasmine.objectContaining({'_name': "Power fist"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Bullgryns",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Bullgryn"}),
+                  jasmine.objectContaining({'_name': "Bullgryn Bone 'ead"}),
+                ],
+                '_modelList': [
+                  "2x Bullgryn (Grenadier Gauntlet, Frag Bombs, Slabshield)",
+                  "Bullgryn Bone 'ead (Grenadier Gauntlet, Frag Bombs, Slabshield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Grenadier Gauntlet"}),
+                  jasmine.objectContaining({'_name': "Frag Bombs"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Hades Breaching Drill Squadron",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Hades Breaching Drill"}),
+                  jasmine.objectContaining({'_name': "Veteran"}),
+                  jasmine.objectContaining({'_name': "Veteran Sergeant"}),
+                ],
+                '_modelList': [
+                  "Hades Breaching Drill (Melta Cutter Drill)",
+                  "Veteran Sergeant (Laspistol, Chainsword, Frag Grenades)",
+                  "9x Veteran w/ Shotgun (Shotgun, Frag Grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Laspistol"}),
+                  jasmine.objectContaining({'_name': "Shotgun"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Melta Cutter Drill"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Special Weapons Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Guardsman"}),
+                ],
+                '_modelList': [
+                  "3x Guardsman (Lasgun, Frag grenade)",
+                  "Guardsman W/ Special Weapon (Grenade Launcher, Frag grenade)",
+                  "Guardsman W/ Special Weapon (Meltagun, Frag grenade)",
+                  "Guardsman W/ Special Weapon (Sniper rifle, Frag grenade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Grenade Launcher (Frag)"}),
+                  jasmine.objectContaining({'_name': "Grenade Launcher (Krak)"}),
+                  jasmine.objectContaining({'_name': "Lasgun"}),
+                  jasmine.objectContaining({'_name': "Meltagun"}),
+                  jasmine.objectContaining({'_name': "Sniper rifle"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Hellhounds",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Hellhound"}),
+                ],
+                '_modelList': [
+                  "Bane Wolf (Turret-mounted Chem Cannon, Heavy Bolter, Stat Damage (HS))",
+                  "Devil Dog (Heavy Bolter, Turret-mounted Melta Cannon, Stat Damage (HS))",
+                  "Hellhound (Heavy Bolter, Turret-mounted Inferno Cannon, Stat Damage (HS))"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Chem Cannon"}),
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                  jasmine.objectContaining({'_name': "Inferno Cannon"}),
+                  jasmine.objectContaining({'_name': "Melta Cannon"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Scout Sentinels",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Scout Sentinel"}),
+                ],
+                '_modelList': [
+                  "Scout Sentinel (Multi-laser)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Multi-laser"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tauros Venator",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Tauros"}),
+                ],
+                '_modelList': [
+                  "Tauros (Twin Multi-Laser)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Twin Multi-Laser"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Hydras",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Hydra"}),
+                ],
+                '_modelList': [
+                  "Hydra (Heavy Bolter, Hydra Quad Autocannon, Stat Damage (HS))"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                  jasmine.objectContaining({'_name': "Hydra Quad Autocannon"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Rapier Laser Destroyer",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Guardsmen Crew"}),
+                  jasmine.objectContaining({'_name': "Rapier"}),
+                ],
+                '_modelList': [
+                  "2x Guardsmen Crew (Lasgun, Frag Grenades)",
+                  "Rapier (Laser Destroyer)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Laser Destroyer"}),
+                  jasmine.objectContaining({'_name': "Lasgun"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Wyverns",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Wyvern"}),
+                ],
+                '_modelList': [
+                  "Wyvern (Heavy Bolter, Wyven Quad Stormshard Mortar)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                  jasmine.objectContaining({'_name': "Wyvern Quad Stormshard Mortar"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
+                  jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Regimental Doctrine",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/KnightsSpec.ts
+++ b/spec/KnightsSpec.ts
@@ -12,132 +12,135 @@ describe("Create40kRoster", function() {
         '_points': 1904,
         '_commandPoints': 0,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Armiger Helverins",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Armiger Helverin"}),
-              ],
-              '_modelList': [
-                "Armiger Helverin (2x Armiger Autocannon, Meltagun)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Armiger Autocannon"}),
-                jasmine.objectContaining({'_name': "Meltagun"}),
-              ],
-              '_explosions': [
-                jasmine.objectContaining({'_name': "Explodes (Armiger)"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Armiger Helverin 1"}),
-                jasmine.objectContaining({'_name': "Armiger Helverin 2"}),
-                jasmine.objectContaining({'_name': "Armiger Helverin 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Armiger Warglaives",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Armiger Warglaive"}),
-              ],
-              '_modelList': [
-                "Armiger Warglaive (Meltagun, Thermal Spear, Reaper Chain-Cleaver)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Meltagun"}),
-                jasmine.objectContaining({'_name': "Thermal Spear"}),
-                jasmine.objectContaining({'_name': "Reaper Chain-Cleaver (Strike)"}),
-                jasmine.objectContaining({'_name': "Reaper Chain-Cleaver (Sweep)"}),
-              ],
-              '_explosions': [
-                jasmine.objectContaining({'_name': "Explodes (Armiger)"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Armiger Warglaive 1"}),
-                jasmine.objectContaining({'_name': "Armiger Warglaive 2"}),
-                jasmine.objectContaining({'_name': "Armiger Warglaive 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Knight Castellan",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Knight Castellan"}),
-              ],
-              '_modelList': [
-                "Knight Castellan (Plasma Decimator, 2x Shieldbreaker Missile, 2x Twin Meltagun, 2x Twin Siegebreaker Cannon, Volcano Lance, Titanic Feet, Character (Knight Lance), Heirloom: Armour of the Sainted Ion, Warlord, Warlord Trait: Fearsome Reputation)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Plasma Decimator (Standard)"}),
-                jasmine.objectContaining({'_name': "Plasma Decimator (Supercharge)"}),
-                jasmine.objectContaining({'_name': "Shieldbreaker Missile"}),
-                jasmine.objectContaining({'_name': "Twin Meltagun"}),
-                jasmine.objectContaining({'_name': "Twin Siegebreaker Cannon"}),
-                jasmine.objectContaining({'_name': "Volcano Lance"}),
-                jasmine.objectContaining({'_name': "Titanic Feet"}),
-              ],
-              '_explosions': [
-                jasmine.objectContaining({'_name': "Dual Plasma Core Explosion"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Knight Castellan 3"}),
-                jasmine.objectContaining({'_name': "Knight Castellan 2"}),
-                jasmine.objectContaining({'_name': "Knight Castellan 1"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Knight Errant",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Knight Errant"}),
-              ],
-              '_modelList': [
-                "Knight Errant (Meltagun, Stormspear Rocket Pod, Thermal Cannon, Thunderstrike gauntlet, Titanic Feet)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Meltagun"}),
-                jasmine.objectContaining({'_name': "Stormspear Rocket Pod"}),
-                jasmine.objectContaining({'_name': "Thermal Cannon"}),
-                jasmine.objectContaining({'_name': "Thunderstrike gauntlet"}),
-                jasmine.objectContaining({'_name': "Titanic Feet"}),
-              ],
-              '_explosions': [
-                jasmine.objectContaining({'_name': "Explodes"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Knight Errant 1"}),
-                jasmine.objectContaining({'_name': "Knight Errant 2"}),
-                jasmine.objectContaining({'_name': "Knight Errant 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Knight Gallant",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Knight Gallant"}),
-              ],
-              '_modelList': [
-                "Knight Gallant (Heavy Stubber, Stormspear Rocket Pod, Reaper Chainsword, Thunderstrike gauntlet, Titanic Feet)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy stubber"}),
-                jasmine.objectContaining({'_name': "Stormspear Rocket Pod"}),
-                jasmine.objectContaining({'_name': "Reaper Chainsword"}),
-                jasmine.objectContaining({'_name': "Thunderstrike gauntlet"}),
-                jasmine.objectContaining({'_name': "Titanic Feet"}),
-              ],
-              '_explosions': [
-                jasmine.objectContaining({'_name': "Explodes"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Knight Gallant 1"}),
-                jasmine.objectContaining({'_name': "Knight Gallant 2"}),
-                jasmine.objectContaining({'_name': "Knight Gallant 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Household Choice",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Armiger Helverins",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Armiger Helverin"}),
+                ],
+                '_modelList': [
+                  "Armiger Helverin (2x Armiger Autocannon, Meltagun)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Armiger Autocannon"}),
+                  jasmine.objectContaining({'_name': "Meltagun"}),
+                ],
+                '_explosions': [
+                  jasmine.objectContaining({'_name': "Explodes (Armiger)"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Armiger Helverin 1"}),
+                  jasmine.objectContaining({'_name': "Armiger Helverin 2"}),
+                  jasmine.objectContaining({'_name': "Armiger Helverin 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Armiger Warglaives",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Armiger Warglaive"}),
+                ],
+                '_modelList': [
+                  "Armiger Warglaive (Meltagun, Thermal Spear, Reaper Chain-Cleaver)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Meltagun"}),
+                  jasmine.objectContaining({'_name': "Thermal Spear"}),
+                  jasmine.objectContaining({'_name': "Reaper Chain-Cleaver (Strike)"}),
+                  jasmine.objectContaining({'_name': "Reaper Chain-Cleaver (Sweep)"}),
+                ],
+                '_explosions': [
+                  jasmine.objectContaining({'_name': "Explodes (Armiger)"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Armiger Warglaive 1"}),
+                  jasmine.objectContaining({'_name': "Armiger Warglaive 2"}),
+                  jasmine.objectContaining({'_name': "Armiger Warglaive 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Knight Castellan",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Knight Castellan"}),
+                ],
+                '_modelList': [
+                  "Knight Castellan (Plasma Decimator, 2x Shieldbreaker Missile, 2x Twin Meltagun, 2x Twin Siegebreaker Cannon, Volcano Lance, Titanic Feet, Character (Knight Lance), Heirloom: Armour of the Sainted Ion, Warlord, Warlord Trait: Fearsome Reputation)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Plasma Decimator (Standard)"}),
+                  jasmine.objectContaining({'_name': "Plasma Decimator (Supercharge)"}),
+                  jasmine.objectContaining({'_name': "Shieldbreaker Missile"}),
+                  jasmine.objectContaining({'_name': "Twin Meltagun"}),
+                  jasmine.objectContaining({'_name': "Twin Siegebreaker Cannon"}),
+                  jasmine.objectContaining({'_name': "Volcano Lance"}),
+                  jasmine.objectContaining({'_name': "Titanic Feet"}),
+                ],
+                '_explosions': [
+                  jasmine.objectContaining({'_name': "Dual Plasma Core Explosion"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Knight Castellan 3"}),
+                  jasmine.objectContaining({'_name': "Knight Castellan 2"}),
+                  jasmine.objectContaining({'_name': "Knight Castellan 1"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Knight Errant",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Knight Errant"}),
+                ],
+                '_modelList': [
+                  "Knight Errant (Meltagun, Stormspear Rocket Pod, Thermal Cannon, Thunderstrike gauntlet, Titanic Feet)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Meltagun"}),
+                  jasmine.objectContaining({'_name': "Stormspear Rocket Pod"}),
+                  jasmine.objectContaining({'_name': "Thermal Cannon"}),
+                  jasmine.objectContaining({'_name': "Thunderstrike gauntlet"}),
+                  jasmine.objectContaining({'_name': "Titanic Feet"}),
+                ],
+                '_explosions': [
+                  jasmine.objectContaining({'_name': "Explodes"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Knight Errant 1"}),
+                  jasmine.objectContaining({'_name': "Knight Errant 2"}),
+                  jasmine.objectContaining({'_name': "Knight Errant 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Knight Gallant",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Knight Gallant"}),
+                ],
+                '_modelList': [
+                  "Knight Gallant (Heavy Stubber, Stormspear Rocket Pod, Reaper Chainsword, Thunderstrike gauntlet, Titanic Feet)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy stubber"}),
+                  jasmine.objectContaining({'_name': "Stormspear Rocket Pod"}),
+                  jasmine.objectContaining({'_name': "Reaper Chainsword"}),
+                  jasmine.objectContaining({'_name': "Thunderstrike gauntlet"}),
+                  jasmine.objectContaining({'_name': "Titanic Feet"}),
+                ],
+                '_explosions': [
+                  jasmine.objectContaining({'_name': "Explodes"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Knight Gallant 1"}),
+                  jasmine.objectContaining({'_name': "Knight Gallant 2"}),
+                  jasmine.objectContaining({'_name': "Knight Gallant 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Household Choice",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/MagnusSpec.ts
+++ b/spec/MagnusSpec.ts
@@ -12,174 +12,186 @@ describe("Create40kRoster", function() {
         '_points': 1315,
         '_commandPoints': 8,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Ahriman",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Ahriman"}),
-              ],
-              '_modelList': [
-                "Ahriman (Inferno Bolt Pistol, Black Staff of Ahriman, Frag & Krak grenades, Smite)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
-                jasmine.objectContaining({'_name': "Black Staff of Ahriman"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Ahriman"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Exalted Sorcerer",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Exalted Sorcerer"}),
-              ],
-              '_modelList': [
-                "Exalted Sorcerer (Inferno Bolt Pistol, Force stave, Frag & Krak grenades, Smite)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
-                jasmine.objectContaining({'_name': "Force stave"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Seeded Strategy"}),
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Exalted Sorcerer"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Chaos Cultists",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Chaos Cultist"}),
-                jasmine.objectContaining({'_name': "Cultist Champion"}),
-              ],
-              '_modelList': [
-                "9x Chaos Cultist w/ Autogun (Autogun)",
-                "Cultist Champion (Autogun)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Autogun"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Rubric Marines",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Aspiring Sorcerer"}),
-                jasmine.objectContaining({'_name': "Rubric Marine"}),
-              ],
-              '_modelList': [
-                "Aspiring Sorcerer (Inferno Bolt Pistol, Force stave, Smite)",
-                "4x Rubric Marine w/ Inferno Boltgun (Inferno boltgun)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
-                jasmine.objectContaining({'_name': "Inferno boltgun"}),
-                jasmine.objectContaining({'_name': "Force stave"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Seeded Strategy"}),
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Aspiring Sorcerer"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tzaangors",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Twistbray"}),
-                jasmine.objectContaining({'_name': "Tzaangors"}),
-              ],
-              '_modelList': [
-                "Twistbray (Tzaangor blades)",
-                "9x Tzaangor w/ Tzaangor Blades (Tzaangor blades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Tzaangor blades"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Helbrute",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Helbrute"}),
-              ],
-              '_modelList': [
-                "Helbrute (Multi-melta, Helbrute fist)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Multi-melta"}),
-                jasmine.objectContaining({'_name': "Helbrute fist"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Scarab Occult Terminators",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Scarab Occult Sorcerer"}),
-                jasmine.objectContaining({'_name': "Scarab Occult Terminator"}),
-              ],
-              '_modelList': [
-                "Scarab Occult Sorcerer (Inferno Combi-bolter, Force stave, Smite)",
-                "4x Terminator (Inferno Combi-bolter, Powersword)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Inferno Combi-bolter"}),
-                jasmine.objectContaining({'_name': "Force stave"}),
-                jasmine.objectContaining({'_name': "Power sword"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Seeded Strategy"}),
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Scarab Occult Sorcerer"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Heldrake",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Heldrake"}),
-              ],
-              '_modelList': [
-                "Heldrake (Hades Autocannon, Heldrake claws)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Hades autocannon"}),
-                jasmine.objectContaining({'_name': "Heldrake claws"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Heldrake"}),
-                jasmine.objectContaining({'_name': "Heldrake1"}),
-                jasmine.objectContaining({'_name': "Heldrake2"}),
-                jasmine.objectContaining({'_name': "Heldrake3"}),
-              ]}),
-          ]}),
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Magnus the Red",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Magnus the Red"}),
-              ],
-              '_modelList': [
-                "Magnus the Red (The Blade of Magnus, Smite, Warlord)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "The Blade of Magnus"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Magnus the Red"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Magnus the Red"}),
-                jasmine.objectContaining({'_name': "Magnus the Red1"}),
-                jasmine.objectContaining({'_name': "Magnus the Red2"}),
-                jasmine.objectContaining({'_name': "Magnus the Red3"}),
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [
+              "Battle-forged CP",
+              "Detachment CP",
+              "Cults of the Legion: Cult of Scheming",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Ahriman",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Ahriman"}),
+                ],
+                '_modelList': [
+                  "Ahriman (Inferno Bolt Pistol, Black Staff of Ahriman, Frag & Krak grenades, Smite)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
+                  jasmine.objectContaining({'_name': "Black Staff of Ahriman"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Ahriman"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Exalted Sorcerer",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Exalted Sorcerer"}),
+                ],
+                '_modelList': [
+                  "Exalted Sorcerer (Inferno Bolt Pistol, Force stave, Frag & Krak grenades, Smite)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
+                  jasmine.objectContaining({'_name': "Force stave"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Seeded Strategy"}),
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Exalted Sorcerer"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Chaos Cultists",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Chaos Cultist"}),
+                  jasmine.objectContaining({'_name': "Cultist Champion"}),
+                ],
+                '_modelList': [
+                  "9x Chaos Cultist w/ Autogun (Autogun)",
+                  "Cultist Champion (Autogun)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Autogun"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Rubric Marines",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Aspiring Sorcerer"}),
+                  jasmine.objectContaining({'_name': "Rubric Marine"}),
+                ],
+                '_modelList': [
+                  "Aspiring Sorcerer (Inferno Bolt Pistol, Force stave, Smite)",
+                  "4x Rubric Marine w/ Inferno Boltgun (Inferno boltgun)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
+                  jasmine.objectContaining({'_name': "Inferno boltgun"}),
+                  jasmine.objectContaining({'_name': "Force stave"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Seeded Strategy"}),
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Aspiring Sorcerer"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tzaangors",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Twistbray"}),
+                  jasmine.objectContaining({'_name': "Tzaangors"}),
+                ],
+                '_modelList': [
+                  "Twistbray (Tzaangor blades)",
+                  "9x Tzaangor w/ Tzaangor Blades (Tzaangor blades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Tzaangor blades"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Helbrute",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Helbrute"}),
+                ],
+                '_modelList': [
+                  "Helbrute (Multi-melta, Helbrute fist)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Multi-melta"}),
+                  jasmine.objectContaining({'_name': "Helbrute fist"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Scarab Occult Terminators",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Scarab Occult Sorcerer"}),
+                  jasmine.objectContaining({'_name': "Scarab Occult Terminator"}),
+                ],
+                '_modelList': [
+                  "Scarab Occult Sorcerer (Inferno Combi-bolter, Force stave, Smite)",
+                  "4x Terminator (Inferno Combi-bolter, Powersword)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Inferno Combi-bolter"}),
+                  jasmine.objectContaining({'_name': "Force stave"}),
+                  jasmine.objectContaining({'_name': "Power sword"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Seeded Strategy"}),
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Scarab Occult Sorcerer"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Heldrake",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Heldrake"}),
+                ],
+                '_modelList': [
+                  "Heldrake (Hades Autocannon, Heldrake claws)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Hades autocannon"}),
+                  jasmine.objectContaining({'_name': "Heldrake claws"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Heldrake"}),
+                  jasmine.objectContaining({'_name': "Heldrake1"}),
+                  jasmine.objectContaining({'_name': "Heldrake2"}),
+                  jasmine.objectContaining({'_name': "Heldrake3"}),
+                ]}),
+            ]
+          }),
+          jasmine.objectContaining({
+            '_configurations': [
+              "Cults of the Legion: Cult of Prophecy",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Magnus the Red",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Magnus the Red"}),
+                ],
+                '_modelList': [
+                  "Magnus the Red (The Blade of Magnus, Smite, Warlord)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "The Blade of Magnus"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Magnus the Red"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Magnus the Red"}),
+                  jasmine.objectContaining({'_name': "Magnus the Red1"}),
+                  jasmine.objectContaining({'_name': "Magnus the Red2"}),
+                  jasmine.objectContaining({'_name': "Magnus the Red3"}),
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/NecronJune20212Spec.ts
+++ b/spec/NecronJune20212Spec.ts
@@ -12,79 +12,85 @@ describe("Create40kRoster", function() {
         '_points': 620,
         '_commandPoints': 3,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Chronomancer",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Chronomancer"}),
-              ],
-              '_modelList': [
-                "Chronomancer (Aeonstave, Chronotendrils)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Aeonstave (Shooting)"}),
-                jasmine.objectContaining({'_name': "Aeonstave (Melee)"}),
-                jasmine.objectContaining({'_name': "Chronotendrils"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Royal Warden",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Royal Warden"}),
-              ],
-              '_modelList': [
-                "Royal Warden (Relic Gauss Blaster, Relic: Veil of Darkness, Warlord, Warlord Trait (Codex 1): Enduring Will)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Relic Gauss Blaster"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Necron Warriors",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Necron Warrior"}),
-              ],
-              '_modelList': [
-                "20x Necron Warrior (Gauss Reaper) (Gauss Reaper)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Gauss Reaper"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Skorpekh Destroyers",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Skorpekh Destroyer"}),
-              ],
-              '_modelList': [
-                "Skorpekh Destroyer (Reap-Blade) (Hyperphase Reap-Blade)",
-                "2x Skorpekh Destroyer (Thresher) (Hyperphase Threshers)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Hyperphase Reap-Blade"}),
-                jasmine.objectContaining({'_name': "Hyperphase Threshers"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Canoptek Scarab Swarms",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Canoptek Scarab Swarm"}),
-              ],
-              '_modelList': [
-                "4x Canoptek Scarab Swarm (Feeder Mandibles)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Feeder Mandibles"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Bound Creation",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Cryptothrall"}),
-              ],
-              '_modelList': [
-                "2x Cryptothrall (Scouring Eye, Scythed Limbs)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Scouring Eye"}),
-                jasmine.objectContaining({'_name': "Scythed Limbs"}),
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [
+              "Dynasty Choice: Dynasty: <Custom>, Dynastic Tradition: Unyielding, Circumstance of Awakening: Healthy Paranoia",
+              "Battle Size: 1. Combat Patrol (0-50 Total PL / 0-500 Points)  [3 CP]",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Chronomancer",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Chronomancer"}),
+                ],
+                '_modelList': [
+                  "Chronomancer (Aeonstave, Chronotendrils)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Aeonstave (Shooting)"}),
+                  jasmine.objectContaining({'_name': "Aeonstave (Melee)"}),
+                  jasmine.objectContaining({'_name': "Chronotendrils"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Royal Warden",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Royal Warden"}),
+                ],
+                '_modelList': [
+                  "Royal Warden (Relic Gauss Blaster, Relic: Veil of Darkness, Warlord, Warlord Trait (Codex 1): Enduring Will)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Relic Gauss Blaster"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Necron Warriors",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Necron Warrior"}),
+                ],
+                '_modelList': [
+                  "20x Necron Warrior (Gauss Reaper) (Gauss Reaper)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Gauss Reaper"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Skorpekh Destroyers",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Skorpekh Destroyer"}),
+                ],
+                '_modelList': [
+                  "Skorpekh Destroyer (Reap-Blade) (Hyperphase Reap-Blade)",
+                  "2x Skorpekh Destroyer (Thresher) (Hyperphase Threshers)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Hyperphase Reap-Blade"}),
+                  jasmine.objectContaining({'_name': "Hyperphase Threshers"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Canoptek Scarab Swarms",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Canoptek Scarab Swarm"}),
+                ],
+                '_modelList': [
+                  "4x Canoptek Scarab Swarm (Feeder Mandibles)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Feeder Mandibles"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Bound Creation",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Cryptothrall"}),
+                ],
+                '_modelList': [
+                  "2x Cryptothrall (Scouring Eye, Scythed Limbs)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Scouring Eye"}),
+                  jasmine.objectContaining({'_name': "Scythed Limbs"}),
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/NecronTestSpec.ts
+++ b/spec/NecronTestSpec.ts
@@ -12,110 +12,113 @@ describe("Create40kRoster", function() {
         '_points': 785,
         '_commandPoints': 0,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Cryptek",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Cryptek"}),
-              ],
-              '_modelList': [
-                "Cryptek (Staff of Light)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Staff of Light (Shooting)"}),
-                jasmine.objectContaining({'_name': "Staff of Light (Melee)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Overlord",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Overlord"}),
-              ],
-              '_modelList': [
-                "Overlord (Staff of Light)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Staff of Light (Shooting)"}),
-                jasmine.objectContaining({'_name': "Staff of Light (Melee)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Immortals",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Immortal"}),
-              ],
-              '_modelList': [
-                "5x Immortal (Gauss Blaster)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Gauss Blaster"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Necron Warriors",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Necron Warrior"}),
-              ],
-              '_modelList': [
-                "10x Necron Warrior (Gauss Flayer)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Gauss Flayer"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Necron Warriors",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Necron Warrior"}),
-              ],
-              '_modelList': [
-                "10x Necron Warrior (Gauss Flayer)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Gauss Flayer"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "C'tan Shard of the Deceiver",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "C'tan Shard of the Deceiver"}),
-              ],
-              '_modelList': [
-                "C'tan Shard of the Deceiver (Star-God Fists)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Star-God Fists"}),
-              ],
-              '_explosions': [
-                jasmine.objectContaining({'_name': "Reality Unravels"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Doom Scythe",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Doom Scythe"}),
-              ],
-              '_modelList': [
-                "Doom Scythe (Death Ray, 2x Tesla Destructor)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Death Ray"}),
-                jasmine.objectContaining({'_name': "Tesla Destructor"}),
-              ],
-              '_explosions': [
-                jasmine.objectContaining({'_name': "Crash and Burn"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Doom Scythe Track 1"}),
-                jasmine.objectContaining({'_name': "Doom Scythe Track 2"}),
-                jasmine.objectContaining({'_name': "Doom Scythe Track 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Dynasty Choice",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Cryptek",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Cryptek"}),
+                ],
+                '_modelList': [
+                  "Cryptek (Staff of Light)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Staff of Light (Shooting)"}),
+                  jasmine.objectContaining({'_name': "Staff of Light (Melee)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Overlord",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Overlord"}),
+                ],
+                '_modelList': [
+                  "Overlord (Staff of Light)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Staff of Light (Shooting)"}),
+                  jasmine.objectContaining({'_name': "Staff of Light (Melee)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Immortals",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Immortal"}),
+                ],
+                '_modelList': [
+                  "5x Immortal (Gauss Blaster)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Gauss Blaster"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Necron Warriors",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Necron Warrior"}),
+                ],
+                '_modelList': [
+                  "10x Necron Warrior (Gauss Flayer)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Gauss Flayer"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Necron Warriors",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Necron Warrior"}),
+                ],
+                '_modelList': [
+                  "10x Necron Warrior (Gauss Flayer)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Gauss Flayer"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "C'tan Shard of the Deceiver",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "C'tan Shard of the Deceiver"}),
+                ],
+                '_modelList': [
+                  "C'tan Shard of the Deceiver (Star-God Fists)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Star-God Fists"}),
+                ],
+                '_explosions': [
+                  jasmine.objectContaining({'_name': "Reality Unravels"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Doom Scythe",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Doom Scythe"}),
+                ],
+                '_modelList': [
+                  "Doom Scythe (Death Ray, 2x Tesla Destructor)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Death Ray"}),
+                  jasmine.objectContaining({'_name': "Tesla Destructor"}),
+                ],
+                '_explosions': [
+                  jasmine.objectContaining({'_name': "Crash and Burn"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Doom Scythe Track 1"}),
+                  jasmine.objectContaining({'_name': "Doom Scythe Track 2"}),
+                  jasmine.objectContaining({'_name': "Doom Scythe Track 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Dynasty Choice",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/SalamanderstestSpec.ts
+++ b/spec/SalamanderstestSpec.ts
@@ -12,95 +12,102 @@ describe("Create40kRoster", function() {
         '_points': 625,
         '_commandPoints': 6,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Captain",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Captain"}),
-              ],
-              '_modelList': [
-                "Captain (Bolt pistol, Combi-melta, Relic blade, Frag & Krak grenades, Forge Master, Obsidian Aquila, Warlord)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Meltagun"}),
-                jasmine.objectContaining({'_name': "Relic blade"}),
-                jasmine.objectContaining({'_name': "Frag grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenades"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tactical Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
-              ],
-              '_modelList': [
-                "3x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Flamer"}),
-                jasmine.objectContaining({'_name': "Frag grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenades"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tactical Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
-              ],
-              '_modelList': [
-                "3x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "Space Marine Sergeant (Bolt pistol, 2x Boltgun, Combi-flamer, Frag & Krak grenades)",
-                "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Flamer"}),
-                jasmine.objectContaining({'_name': "Frag grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenades"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Redemptor Dreadnought",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought [1] (7+ wounds remaining)"}),
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought [2] (4-6 wounds remaining)"}),
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought [3] (1-3 wounds remaining)"}),
-              ],
-              '_modelList': [
-                "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Heavy flamer"}),
-                jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
-                jasmine.objectContaining({'_name': "Redemptor Fist"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Devastator Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Devastator Marine"}),
-                jasmine.objectContaining({'_name': "Devastator Marine Sergeant"}),
-              ],
-              '_modelList': [
-                "Devastator Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
-                "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Multi-melta, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-                jasmine.objectContaining({'_name': "Multi-melta"}),
-                jasmine.objectContaining({'_name': "Frag grenades"}),
-                jasmine.objectContaining({'_name': "Krak grenades"}),
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [
+              "PC: SA - **Chapter Selector**: Salamanders",
+              "Battle Size: 2. Incursion (51-100 Total PL / 501-1000 Points)  [6 CP]",
+              "Gametype: Matched",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Captain",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Captain"}),
+                ],
+                '_modelList': [
+                  "Captain (Bolt pistol, Combi-melta, Relic blade, Frag & Krak grenades, Forge Master, Obsidian Aquila, Warlord)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Meltagun"}),
+                  jasmine.objectContaining({'_name': "Relic blade"}),
+                  jasmine.objectContaining({'_name': "Frag grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenades"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tactical Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
+                ],
+                '_modelList': [
+                  "3x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Flamer"}),
+                  jasmine.objectContaining({'_name': "Frag grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenades"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tactical Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
+                ],
+                '_modelList': [
+                  "3x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Space Marine Sergeant (Bolt pistol, 2x Boltgun, Combi-flamer, Frag & Krak grenades)",
+                  "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Flamer"}),
+                  jasmine.objectContaining({'_name': "Frag grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenades"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Redemptor Dreadnought",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought [1] (7+ wounds remaining)"}),
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought [2] (4-6 wounds remaining)"}),
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought [3] (1-3 wounds remaining)"}),
+                ],
+                '_modelList': [
+                  "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Heavy flamer"}),
+                  jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
+                  jasmine.objectContaining({'_name': "Redemptor Fist"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Devastator Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Devastator Marine"}),
+                  jasmine.objectContaining({'_name': "Devastator Marine Sergeant"}),
+                ],
+                '_modelList': [
+                  "Devastator Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
+                  "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Multi-melta, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                  jasmine.objectContaining({'_name': "Multi-melta"}),
+                  jasmine.objectContaining({'_name': "Frag grenades"}),
+                  jasmine.objectContaining({'_name': "Krak grenades"}),
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/Tau_TestSpec.ts
+++ b/spec/Tau_TestSpec.ts
@@ -12,397 +12,403 @@ describe("Create40kRoster", function() {
         '_points': 1981,
         '_commandPoints': 13,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Aun'Shi",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Aun'Shi"}),
-              ],
-              '_modelList': [
-                "Aun'Shi (Honour blade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Honour blade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Commander in XV8 Crisis Battlesuit",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Commander in XV8 Crisis Battlesuit"}),
-              ],
-              '_modelList': [
-                "Commander in XV8 Crisis Battlesuit (Burst cannon, Missile pod)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Burst cannon"}),
-                jasmine.objectContaining({'_name': "Missile pod"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Commander in XV85 Enforcer Battlesuit",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Commander in XV85 Enforcer Battlesuit"}),
-              ],
-              '_modelList': [
-                "Commander in XV85 Enforcer Battlesuit (Burst cannon, Missile pod)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Burst cannon"}),
-                jasmine.objectContaining({'_name': "Missile pod"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Strike Team",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Fire Warrior"}),
-              ],
-              '_modelList': [
-                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Pulse rifle"}),
-                jasmine.objectContaining({'_name': "Photon grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Strike Team",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Fire Warrior"}),
-              ],
-              '_modelList': [
-                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Pulse rifle"}),
-                jasmine.objectContaining({'_name': "Photon grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Strike Team",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Fire Warrior"}),
-              ],
-              '_modelList': [
-                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Pulse rifle"}),
-                jasmine.objectContaining({'_name': "Photon grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Kroot Shaper",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Kroot Shaper"}),
-              ],
-              '_modelList': [
-                "Kroot Shaper (Kroot rifle, Ritual blade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Kroot rifle (shooting)"}),
-                jasmine.objectContaining({'_name': "Kroot rifle (melee)"}),
-                jasmine.objectContaining({'_name': "Ritual blade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "XV95 Ghostkeel Battlesuit",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "MV5 Stealth Drone"}),
-                jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre"}),
-              ],
-              '_modelList': [
-                "XV95 Ghostkeel Battlesuit (2x Flamer, Fusion collider)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Flamer"}),
-                jasmine.objectContaining({'_name': "Fusion collider"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre 1"}),
-                jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre 2"}),
-                jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "AX3 Razorshark Strike Fighter",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter"}),
-              ],
-              '_modelList': [
-                "AX3 Razorshark Strike Fighter (Burst cannon, Quad ion turret, 2x Seeker missile)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Burst cannon"}),
-                jasmine.objectContaining({'_name': "Quad ion turret (Overcharge)"}),
-                jasmine.objectContaining({'_name': "Quad ion turret (Standard)"}),
-                jasmine.objectContaining({'_name': "Seeker missile"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter 1"}),
-                jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter 2"}),
-                jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "TY7 Devilfish",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "MV1 Gun Drone"}),
-                jasmine.objectContaining({'_name': "TY7 Devilfish"}),
-              ],
-              '_modelList': [
-                "TY7 Devilfish (Burst cannon, 4x Pulse carbine)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Burst cannon"}),
-                jasmine.objectContaining({'_name': "Pulse carbine"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "TY7 Devilfish 1"}),
-                jasmine.objectContaining({'_name': "TY7 Devilfish 2"}),
-                jasmine.objectContaining({'_name': "TY7 Devilfish 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Detachment CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Commander Farsight",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Commander Farsight"}),
-              ],
-              '_modelList': [
-                "Commander Farsight (High-intensity plasma rifle, Dawn blade, Warlord)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "High-intensity plasma rifle"}),
-                jasmine.objectContaining({'_name': "Dawn blade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Darkstrider",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Darkstrider"}),
-              ],
-              '_modelList': [
-                "Darkstrider (Markerlight, Pulse carbine, Photon grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Markerlight"}),
-                jasmine.objectContaining({'_name': "Pulse carbine"}),
-                jasmine.objectContaining({'_name': "Photon grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Breacher Team",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Fire Warrior"}),
-              ],
-              '_modelList': [
-                "5x Fire Warrior (Pulse blaster, Photon grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Pulse blaster (1 Close range)"}),
-                jasmine.objectContaining({'_name': "Pulse blaster (2 Medium range)"}),
-                jasmine.objectContaining({'_name': "Pulse blaster (3 Long range)"}),
-                jasmine.objectContaining({'_name': "Photon grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Kroot Carnivores",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Kroot"}),
-              ],
-              '_modelList': [
-                "10x Kroot (Kroot rifle)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Kroot rifle (shooting)"}),
-                jasmine.objectContaining({'_name': "Kroot rifle (melee)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Strike Team",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Fire Warrior"}),
-              ],
-              '_modelList': [
-                "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Pulse rifle"}),
-                jasmine.objectContaining({'_name': "Photon grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "DX-4 Technical Drones",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "DX-4 Technical Drone"}),
-              ],
-              '_modelList': [
-                "2x DX-4 Technical Drone (Defensive charge)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Defensive charge"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "DX-4 Technical Drones",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "DX-4 Technical Drone"}),
-              ],
-              '_modelList': [
-                "2x DX-4 Technical Drone (Defensive charge)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Defensive charge"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Dahyak Grekh",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Dahyak Grekh"}),
-              ],
-              '_modelList': [
-                "Dahyak Grekh (Kroot pistol, Kroot rifle)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Kroot pistol"}),
-                jasmine.objectContaining({'_name': "Kroot rifle (shooting)"}),
-                jasmine.objectContaining({'_name': "Kroot rifle (melee)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "XV104 Riptide Battlesuit",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
-              ],
-              '_modelList': [
-                "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy burst cannon"}),
-                jasmine.objectContaining({'_name': "Smart missile system"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 1"}),
-                jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 2"}),
-                jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "XV104 Riptide Battlesuit",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
-              ],
-              '_modelList': [
-                "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy burst cannon"}),
-                jasmine.objectContaining({'_name': "Smart missile system"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 1"}),
-                jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 2"}),
-                jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "XV104 Riptide Battlesuit",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
-              ],
-              '_modelList': [
-                "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Heavy burst cannon"}),
-                jasmine.objectContaining({'_name': "Smart missile system"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 1"}),
-                jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 2"}),
-                jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tactical Drones",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "MV1 Gun Drone"}),
-              ],
-              '_modelList': [
-                "4x MV1 Gun Drone (2x Pulse carbine)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Pulse carbine"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tactical Drones",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "MV1 Gun Drone"}),
-              ],
-              '_modelList': [
-                "4x MV1 Gun Drone (2x Pulse carbine)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Pulse carbine"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tactical Drones",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "MV1 Gun Drone"}),
-              ],
-              '_modelList': [
-                "4x MV1 Gun Drone (2x Pulse carbine)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Pulse carbine"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Great Knarloc",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Great Knarloc"}),
-              ],
-              '_modelList': [
-                "Great Knarloc (Razor talons, Crushing Beak)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Razor talons"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Great Knarloc",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Great Knarloc"}),
-              ],
-              '_modelList': [
-                "Great Knarloc (Razor talons, Crushing Beak)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Razor talons"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Heavy Gun Drone Squadron",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Heavy Gun Drone"}),
-              ],
-              '_modelList': [
-                "2x Heavy Gun Drone w/ 2x BC (Burst cannon)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Burst cannon"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Battle-forged CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Detachment CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Aun'Shi",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Aun'Shi"}),
+                ],
+                '_modelList': [
+                  "Aun'Shi (Honour blade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Honour blade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Commander in XV8 Crisis Battlesuit",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Commander in XV8 Crisis Battlesuit"}),
+                ],
+                '_modelList': [
+                  "Commander in XV8 Crisis Battlesuit (Burst cannon, Missile pod)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Burst cannon"}),
+                  jasmine.objectContaining({'_name': "Missile pod"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Commander in XV85 Enforcer Battlesuit",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Commander in XV85 Enforcer Battlesuit"}),
+                ],
+                '_modelList': [
+                  "Commander in XV85 Enforcer Battlesuit (Burst cannon, Missile pod)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Burst cannon"}),
+                  jasmine.objectContaining({'_name': "Missile pod"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Strike Team",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Fire Warrior"}),
+                ],
+                '_modelList': [
+                  "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Pulse rifle"}),
+                  jasmine.objectContaining({'_name': "Photon grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Strike Team",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Fire Warrior"}),
+                ],
+                '_modelList': [
+                  "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Pulse rifle"}),
+                  jasmine.objectContaining({'_name': "Photon grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Strike Team",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Fire Warrior"}),
+                ],
+                '_modelList': [
+                  "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Pulse rifle"}),
+                  jasmine.objectContaining({'_name': "Photon grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Kroot Shaper",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Kroot Shaper"}),
+                ],
+                '_modelList': [
+                  "Kroot Shaper (Kroot rifle, Ritual blade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Kroot rifle (shooting)"}),
+                  jasmine.objectContaining({'_name': "Kroot rifle (melee)"}),
+                  jasmine.objectContaining({'_name': "Ritual blade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "XV95 Ghostkeel Battlesuit",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "MV5 Stealth Drone"}),
+                  jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre"}),
+                ],
+                '_modelList': [
+                  "XV95 Ghostkeel Battlesuit (2x Flamer, Fusion collider)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Flamer"}),
+                  jasmine.objectContaining({'_name': "Fusion collider"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre 1"}),
+                  jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre 2"}),
+                  jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "AX3 Razorshark Strike Fighter",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter"}),
+                ],
+                '_modelList': [
+                  "AX3 Razorshark Strike Fighter (Burst cannon, Quad ion turret, 2x Seeker missile)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Burst cannon"}),
+                  jasmine.objectContaining({'_name': "Quad ion turret (Overcharge)"}),
+                  jasmine.objectContaining({'_name': "Quad ion turret (Standard)"}),
+                  jasmine.objectContaining({'_name': "Seeker missile"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter 1"}),
+                  jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter 2"}),
+                  jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "TY7 Devilfish",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "MV1 Gun Drone"}),
+                  jasmine.objectContaining({'_name': "TY7 Devilfish"}),
+                ],
+                '_modelList': [
+                  "TY7 Devilfish (Burst cannon, 4x Pulse carbine)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Burst cannon"}),
+                  jasmine.objectContaining({'_name': "Pulse carbine"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "TY7 Devilfish 1"}),
+                  jasmine.objectContaining({'_name': "TY7 Devilfish 2"}),
+                  jasmine.objectContaining({'_name': "TY7 Devilfish 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Detachment CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Commander Farsight",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Commander Farsight"}),
+                ],
+                '_modelList': [
+                  "Commander Farsight (High-intensity plasma rifle, Dawn blade, Warlord)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "High-intensity plasma rifle"}),
+                  jasmine.objectContaining({'_name': "Dawn blade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Darkstrider",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Darkstrider"}),
+                ],
+                '_modelList': [
+                  "Darkstrider (Markerlight, Pulse carbine, Photon grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Markerlight"}),
+                  jasmine.objectContaining({'_name': "Pulse carbine"}),
+                  jasmine.objectContaining({'_name': "Photon grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Breacher Team",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Fire Warrior"}),
+                ],
+                '_modelList': [
+                  "5x Fire Warrior (Pulse blaster, Photon grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Pulse blaster (1 Close range)"}),
+                  jasmine.objectContaining({'_name': "Pulse blaster (2 Medium range)"}),
+                  jasmine.objectContaining({'_name': "Pulse blaster (3 Long range)"}),
+                  jasmine.objectContaining({'_name': "Photon grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Kroot Carnivores",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Kroot"}),
+                ],
+                '_modelList': [
+                  "10x Kroot (Kroot rifle)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Kroot rifle (shooting)"}),
+                  jasmine.objectContaining({'_name': "Kroot rifle (melee)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Strike Team",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Fire Warrior"}),
+                ],
+                '_modelList': [
+                  "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Pulse rifle"}),
+                  jasmine.objectContaining({'_name': "Photon grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "DX-4 Technical Drones",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "DX-4 Technical Drone"}),
+                ],
+                '_modelList': [
+                  "2x DX-4 Technical Drone (Defensive charge)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Defensive charge"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "DX-4 Technical Drones",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "DX-4 Technical Drone"}),
+                ],
+                '_modelList': [
+                  "2x DX-4 Technical Drone (Defensive charge)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Defensive charge"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Dahyak Grekh",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Dahyak Grekh"}),
+                ],
+                '_modelList': [
+                  "Dahyak Grekh (Kroot pistol, Kroot rifle)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Kroot pistol"}),
+                  jasmine.objectContaining({'_name': "Kroot rifle (shooting)"}),
+                  jasmine.objectContaining({'_name': "Kroot rifle (melee)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "XV104 Riptide Battlesuit",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
+                ],
+                '_modelList': [
+                  "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy burst cannon"}),
+                  jasmine.objectContaining({'_name': "Smart missile system"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 1"}),
+                  jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 2"}),
+                  jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "XV104 Riptide Battlesuit",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
+                ],
+                '_modelList': [
+                  "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy burst cannon"}),
+                  jasmine.objectContaining({'_name': "Smart missile system"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 1"}),
+                  jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 2"}),
+                  jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "XV104 Riptide Battlesuit",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
+                ],
+                '_modelList': [
+                  "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Heavy burst cannon"}),
+                  jasmine.objectContaining({'_name': "Smart missile system"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 1"}),
+                  jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 2"}),
+                  jasmine.objectContaining({'_name': "XV104 Riptide Shas'vre 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tactical Drones",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "MV1 Gun Drone"}),
+                ],
+                '_modelList': [
+                  "4x MV1 Gun Drone (2x Pulse carbine)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Pulse carbine"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tactical Drones",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "MV1 Gun Drone"}),
+                ],
+                '_modelList': [
+                  "4x MV1 Gun Drone (2x Pulse carbine)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Pulse carbine"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tactical Drones",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "MV1 Gun Drone"}),
+                ],
+                '_modelList': [
+                  "4x MV1 Gun Drone (2x Pulse carbine)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Pulse carbine"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Great Knarloc",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Great Knarloc"}),
+                ],
+                '_modelList': [
+                  "Great Knarloc (Razor talons, Crushing Beak)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Razor talons"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Great Knarloc",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Great Knarloc"}),
+                ],
+                '_modelList': [
+                  "Great Knarloc (Razor talons, Crushing Beak)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Razor talons"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Heavy Gun Drone Squadron",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Heavy Gun Drone"}),
+                ],
+                '_modelList': [
+                  "2x Heavy Gun Drone w/ 2x BC (Burst cannon)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Burst cannon"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Battle-forged CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Detachment CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/TyranidsTestSpec.ts
+++ b/spec/TyranidsTestSpec.ts
@@ -12,358 +12,364 @@ describe("Create40kRoster", function() {
         '_points': 1798,
         '_commandPoints': 6,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Abominant",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Abominant"}),
-              ],
-              '_modelList': [
-                "Abominant (Familiar Claws, Power Sledgehammer, Rending Claw)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Familiar Claws"}),
-                jasmine.objectContaining({'_name': "Power Sledgehammer"}),
-                jasmine.objectContaining({'_name': "Rending Claw(s)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Magus",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Familiar"}),
-                jasmine.objectContaining({'_name': "Magus"}),
-              ],
-              '_modelList': [
-                "Magus (Autopistol, Cultist Knife, Force stave, Power: Psychic Stimulus)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Autopistol"}),
-                jasmine.objectContaining({'_name': "Cultist Knife"}),
-                jasmine.objectContaining({'_name': "Force stave"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Psychic Stimulus"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Magus"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Acolyte Hybrids",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Acolyte Hybrid"}),
-                jasmine.objectContaining({'_name': "Acolyte Leader"}),
-              ],
-              '_modelList': [
-                "4x Acolyte Hybrid (Autopistol, Cultist Knife, Rending Claw, Blasting Charges)",
-                "Acolyte Hybrid (Heavy Weapon) (Autopistol, Heavy Rock Saw, Blasting Charges)",
-                "Acolyte Leader (Autopistol, Cultist Knife, Rending Claw, Blasting Charges)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Autopistol"}),
-                jasmine.objectContaining({'_name': "Cultist Knife"}),
-                jasmine.objectContaining({'_name': "Heavy Rock Saw"}),
-                jasmine.objectContaining({'_name': "Rending Claw(s)"}),
-                jasmine.objectContaining({'_name': "Blasting Charge"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Brood Brothers Infantry Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Brood Brother"}),
-                jasmine.objectContaining({'_name': "Brood Brothers Leader"}),
-                jasmine.objectContaining({'_name': "Brood Brothers Weapons Team"}),
-              ],
-              '_modelList': [
-                "9x Brood Brother (Lasgun, Frag Grenades)",
-                "Brood Brother (Flamer) (Flamer, Frag Grenades)",
-                "Brood Brother (Grenade) (Grenade Launcher, Frag Grenades)",
-                "Brood Brother (Vox-caster) (Lasgun, Frag Grenades, Cult Vox-caster)",
-                "Brood Brothers Leader (Laspistol, Chainsword, Frag Grenades)",
-                "Brood Brothers Weapons Team (Lascannon, Lasgun, Frag Grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Flamer"}),
-                jasmine.objectContaining({'_name': "Grenade Launcher (Frag)"}),
-                jasmine.objectContaining({'_name': "Grenade Launcher (Krak)"}),
-                jasmine.objectContaining({'_name': "Lascannon"}),
-                jasmine.objectContaining({'_name': "Lasgun"}),
-                jasmine.objectContaining({'_name': "Laspistol"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Frag Grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Neophyte Hybrids",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Neophyte Hybrid"}),
-                jasmine.objectContaining({'_name': "Neophyte Leader"}),
-              ],
-              '_modelList': [
-                "9x Neophyte Hybrid (Autogun, Autopistol, Blasting Charges)",
-                "Neophyte Hybrid (Flamer) (Autopistol, Flamer, Blasting Charges)",
-                "Neophyte Hybrid (Lasgun) (Autopistol, Lasgun, Blasting Charges)",
-                "Neophyte Hybrid (Mining) (Autopistol, Mining Laser, Blasting Charges)",
-                "Neophyte Hybrid (Shotgun) (Autopistol, Shotgun, Blasting Charges)",
-                "Neophyte Leader (Autogun, Autopistol, Blasting Charges)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Autogun"}),
-                jasmine.objectContaining({'_name': "Autopistol"}),
-                jasmine.objectContaining({'_name': "Flamer"}),
-                jasmine.objectContaining({'_name': "Lasgun"}),
-                jasmine.objectContaining({'_name': "Mining Laser"}),
-                jasmine.objectContaining({'_name': "Shotgun"}),
-                jasmine.objectContaining({'_name': "Blasting Charge"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Atalan Jackals",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Atalan Jackal"}),
-                jasmine.objectContaining({'_name': "Atalan Leader"}),
-              ],
-              '_modelList': [
-                "3x Atalan Jackal (Autopistol, Blasting Charges)",
-                "Atalan Leader (Autopistol, Power Pick, Blasting Charges, Demolition Charge)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Autopistol"}),
-                jasmine.objectContaining({'_name': "Power Pick"}),
-                jasmine.objectContaining({'_name': "Blasting Charge"}),
-                jasmine.objectContaining({'_name': "Demolition Charge"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Cult Leman Russ",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Cult Leman Russ"}),
-              ],
-              '_modelList': [
-                "Cult Leman Russ (Battle Cannon, Heavy Bolter, 2x Heavy Flamer, Heavy Stubber, Hunter-killer Missile)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Battle Cannon"}),
-                jasmine.objectContaining({'_name': "Heavy bolter"}),
-                jasmine.objectContaining({'_name': "Heavy flamer"}),
-                jasmine.objectContaining({'_name': "Heavy stubber"}),
-                jasmine.objectContaining({'_name': "Hunter-killer missile"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Cult Leman Russ (1)"}),
-                jasmine.objectContaining({'_name': "Cult Leman Russ (2)"}),
-                jasmine.objectContaining({'_name': "Cult Leman Russ (3)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Goliath Rockgrinder",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Goliath Rockgrinder"}),
-              ],
-              '_modelList': [
-                "Goliath Rockgrinder (Cache of Demolition Charges, Heavy Mining Laser, Heavy Stubber, Drilldozer Blade)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Cache of Demolition Charges"}),
-                jasmine.objectContaining({'_name': "Heavy Mining Laser"}),
-                jasmine.objectContaining({'_name': "Heavy stubber"}),
-                jasmine.objectContaining({'_name': "Drilldozer Blade"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Goliath Rockgrinder (1)"}),
-                jasmine.objectContaining({'_name': "Goliath Rockgrinder (2)"}),
-                jasmine.objectContaining({'_name': "Goliath Rockgrinder (3)"}),
-              ]}),
-          ]}),
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Broodlord",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Broodlord"}),
-              ],
-              '_modelList': [
-                "Broodlord (Monstrous Rending Claws, Adrenal Webs, Power: Catalyst, Power: Smite, Resonance Barb, Warlord, Warlord Trait: Instinctive Killer)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Monstrous Rending Claws"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-                jasmine.objectContaining({'_name': "Catalyst"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Broodlord"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Hive Tyrant",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Hive Tyrant"}),
-              ],
-              '_modelList': [
-                "Hive Tyrant (2x Monstrous Scything Talons, Prehensile Pincer Tail)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Monstrous Scything Talons"}),
-                jasmine.objectContaining({'_name': "Prehensile Pincer Tail"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Hive Tyrant"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Hive Tyrant (1)"}),
-                jasmine.objectContaining({'_name': "Hive Tyrant (3)"}),
-                jasmine.objectContaining({'_name': "Hive Tyrant (2)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Hormagaunts",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Hormagaunt"}),
-              ],
-              '_modelList': [
-                "10x Hormagaunt (Scything Talons)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Scything Talons"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Termagants",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Termagant"}),
-              ],
-              '_modelList': [
-                "10x Termagant (Fleshborer) (Fleshborer)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fleshborer"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Tyranid Warriors",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Tyranid Warrior"}),
-              ],
-              '_modelList': [
-                "Tyranid Warrior (Devourer, Boneswords)",
-                "Tyranid Warrior (Devourer, Lash Whip and Bonesword)",
-                "Tyranid Warrior (Devourer, Rending Claws)",
-                "Tyranid Warrior (Devourer, Scything Talons)",
-                "Tyranid Warrior (Bio-cannon) (Venom Cannon, Scything Talons)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Devourer"}),
-                jasmine.objectContaining({'_name': "Venom Cannon"}),
-                jasmine.objectContaining({'_name': "Boneswords"}),
-                jasmine.objectContaining({'_name': "Lash Whip and Bonesword"}),
-                jasmine.objectContaining({'_name': "Rending Claws"}),
-                jasmine.objectContaining({'_name': "Scything Talons"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Hive Guard",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Hive Guard"}),
-              ],
-              '_modelList': [
-                "3x Hive Guard (Impaler) (Impaler Cannon)",
-                "Hive Guard (Shock) (Shockcannon)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Impaler Cannon"}),
-                jasmine.objectContaining({'_name': "Shockcannon"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Carnifexes",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Carnifex"}),
-              ],
-              '_modelList': [
-                "Carnifex (2x Monstrous Scything Talons)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Monstrous Scything Talons"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Exocrine",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Exocrine"}),
-              ],
-              '_modelList': [
-                "Exocrine (Bio-plasmic Cannon, Powerful Limbs)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bio-plasmic Cannon"}),
-                jasmine.objectContaining({'_name': "Powerful Limbs"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Exocrine (1)"}),
-                jasmine.objectContaining({'_name': "Exocrine (2)"}),
-                jasmine.objectContaining({'_name': "Exocrine (3)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Toxicrene",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Toxicrene"}),
-              ],
-              '_modelList': [
-                "Toxicrene (Chocking Spores, Massive Toxic Lashes)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Choking Spores"}),
-                jasmine.objectContaining({'_name': "Massive Toxic Lashes (Shooting)"}),
-                jasmine.objectContaining({'_name': "Massive Toxic Lashes (Melee)"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Toxicrene (1)"}),
-                jasmine.objectContaining({'_name': "Toxicrene (2)"}),
-                jasmine.objectContaining({'_name': "Toxicrene (3)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Battle-forged CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Detachment CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Hive Fleet",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Stratagem: Bounty of the Hive Fleet",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Stratagem: Progeny of the Hive",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Abominant",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Abominant"}),
+                ],
+                '_modelList': [
+                  "Abominant (Familiar Claws, Power Sledgehammer, Rending Claw)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Familiar Claws"}),
+                  jasmine.objectContaining({'_name': "Power Sledgehammer"}),
+                  jasmine.objectContaining({'_name': "Rending Claw(s)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Magus",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Familiar"}),
+                  jasmine.objectContaining({'_name': "Magus"}),
+                ],
+                '_modelList': [
+                  "Magus (Autopistol, Cultist Knife, Force stave, Power: Psychic Stimulus)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Autopistol"}),
+                  jasmine.objectContaining({'_name': "Cultist Knife"}),
+                  jasmine.objectContaining({'_name': "Force stave"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Psychic Stimulus"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Magus"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Acolyte Hybrids",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Acolyte Hybrid"}),
+                  jasmine.objectContaining({'_name': "Acolyte Leader"}),
+                ],
+                '_modelList': [
+                  "4x Acolyte Hybrid (Autopistol, Cultist Knife, Rending Claw, Blasting Charges)",
+                  "Acolyte Hybrid (Heavy Weapon) (Autopistol, Heavy Rock Saw, Blasting Charges)",
+                  "Acolyte Leader (Autopistol, Cultist Knife, Rending Claw, Blasting Charges)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Autopistol"}),
+                  jasmine.objectContaining({'_name': "Cultist Knife"}),
+                  jasmine.objectContaining({'_name': "Heavy Rock Saw"}),
+                  jasmine.objectContaining({'_name': "Rending Claw(s)"}),
+                  jasmine.objectContaining({'_name': "Blasting Charge"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Brood Brothers Infantry Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Brood Brother"}),
+                  jasmine.objectContaining({'_name': "Brood Brothers Leader"}),
+                  jasmine.objectContaining({'_name': "Brood Brothers Weapons Team"}),
+                ],
+                '_modelList': [
+                  "9x Brood Brother (Lasgun, Frag Grenades)",
+                  "Brood Brother (Flamer) (Flamer, Frag Grenades)",
+                  "Brood Brother (Grenade) (Grenade Launcher, Frag Grenades)",
+                  "Brood Brother (Vox-caster) (Lasgun, Frag Grenades, Cult Vox-caster)",
+                  "Brood Brothers Leader (Laspistol, Chainsword, Frag Grenades)",
+                  "Brood Brothers Weapons Team (Lascannon, Lasgun, Frag Grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Flamer"}),
+                  jasmine.objectContaining({'_name': "Grenade Launcher (Frag)"}),
+                  jasmine.objectContaining({'_name': "Grenade Launcher (Krak)"}),
+                  jasmine.objectContaining({'_name': "Lascannon"}),
+                  jasmine.objectContaining({'_name': "Lasgun"}),
+                  jasmine.objectContaining({'_name': "Laspistol"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Frag Grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Neophyte Hybrids",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Neophyte Hybrid"}),
+                  jasmine.objectContaining({'_name': "Neophyte Leader"}),
+                ],
+                '_modelList': [
+                  "9x Neophyte Hybrid (Autogun, Autopistol, Blasting Charges)",
+                  "Neophyte Hybrid (Flamer) (Autopistol, Flamer, Blasting Charges)",
+                  "Neophyte Hybrid (Lasgun) (Autopistol, Lasgun, Blasting Charges)",
+                  "Neophyte Hybrid (Mining) (Autopistol, Mining Laser, Blasting Charges)",
+                  "Neophyte Hybrid (Shotgun) (Autopistol, Shotgun, Blasting Charges)",
+                  "Neophyte Leader (Autogun, Autopistol, Blasting Charges)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Autogun"}),
+                  jasmine.objectContaining({'_name': "Autopistol"}),
+                  jasmine.objectContaining({'_name': "Flamer"}),
+                  jasmine.objectContaining({'_name': "Lasgun"}),
+                  jasmine.objectContaining({'_name': "Mining Laser"}),
+                  jasmine.objectContaining({'_name': "Shotgun"}),
+                  jasmine.objectContaining({'_name': "Blasting Charge"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Atalan Jackals",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Atalan Jackal"}),
+                  jasmine.objectContaining({'_name': "Atalan Leader"}),
+                ],
+                '_modelList': [
+                  "3x Atalan Jackal (Autopistol, Blasting Charges)",
+                  "Atalan Leader (Autopistol, Power Pick, Blasting Charges, Demolition Charge)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Autopistol"}),
+                  jasmine.objectContaining({'_name': "Power Pick"}),
+                  jasmine.objectContaining({'_name': "Blasting Charge"}),
+                  jasmine.objectContaining({'_name': "Demolition Charge"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Cult Leman Russ",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Cult Leman Russ"}),
+                ],
+                '_modelList': [
+                  "Cult Leman Russ (Battle Cannon, Heavy Bolter, 2x Heavy Flamer, Heavy Stubber, Hunter-killer Missile)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Battle Cannon"}),
+                  jasmine.objectContaining({'_name': "Heavy bolter"}),
+                  jasmine.objectContaining({'_name': "Heavy flamer"}),
+                  jasmine.objectContaining({'_name': "Heavy stubber"}),
+                  jasmine.objectContaining({'_name': "Hunter-killer missile"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Cult Leman Russ (1)"}),
+                  jasmine.objectContaining({'_name': "Cult Leman Russ (2)"}),
+                  jasmine.objectContaining({'_name': "Cult Leman Russ (3)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Goliath Rockgrinder",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Goliath Rockgrinder"}),
+                ],
+                '_modelList': [
+                  "Goliath Rockgrinder (Cache of Demolition Charges, Heavy Mining Laser, Heavy Stubber, Drilldozer Blade)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Cache of Demolition Charges"}),
+                  jasmine.objectContaining({'_name': "Heavy Mining Laser"}),
+                  jasmine.objectContaining({'_name': "Heavy stubber"}),
+                  jasmine.objectContaining({'_name': "Drilldozer Blade"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Goliath Rockgrinder (1)"}),
+                  jasmine.objectContaining({'_name': "Goliath Rockgrinder (2)"}),
+                  jasmine.objectContaining({'_name': "Goliath Rockgrinder (3)"}),
+                ]}),
+            ]
+          }),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Broodlord",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Broodlord"}),
+                ],
+                '_modelList': [
+                  "Broodlord (Monstrous Rending Claws, Adrenal Webs, Power: Catalyst, Power: Smite, Resonance Barb, Warlord, Warlord Trait: Instinctive Killer)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Monstrous Rending Claws"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                  jasmine.objectContaining({'_name': "Catalyst"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Broodlord"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Hive Tyrant",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Hive Tyrant"}),
+                ],
+                '_modelList': [
+                  "Hive Tyrant (2x Monstrous Scything Talons, Prehensile Pincer Tail)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Monstrous Scything Talons"}),
+                  jasmine.objectContaining({'_name': "Prehensile Pincer Tail"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Hive Tyrant"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Hive Tyrant (1)"}),
+                  jasmine.objectContaining({'_name': "Hive Tyrant (3)"}),
+                  jasmine.objectContaining({'_name': "Hive Tyrant (2)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Hormagaunts",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Hormagaunt"}),
+                ],
+                '_modelList': [
+                  "10x Hormagaunt (Scything Talons)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Scything Talons"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Termagants",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Termagant"}),
+                ],
+                '_modelList': [
+                  "10x Termagant (Fleshborer) (Fleshborer)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fleshborer"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Tyranid Warriors",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Tyranid Warrior"}),
+                ],
+                '_modelList': [
+                  "Tyranid Warrior (Devourer, Boneswords)",
+                  "Tyranid Warrior (Devourer, Lash Whip and Bonesword)",
+                  "Tyranid Warrior (Devourer, Rending Claws)",
+                  "Tyranid Warrior (Devourer, Scything Talons)",
+                  "Tyranid Warrior (Bio-cannon) (Venom Cannon, Scything Talons)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Devourer"}),
+                  jasmine.objectContaining({'_name': "Venom Cannon"}),
+                  jasmine.objectContaining({'_name': "Boneswords"}),
+                  jasmine.objectContaining({'_name': "Lash Whip and Bonesword"}),
+                  jasmine.objectContaining({'_name': "Rending Claws"}),
+                  jasmine.objectContaining({'_name': "Scything Talons"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Hive Guard",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Hive Guard"}),
+                ],
+                '_modelList': [
+                  "3x Hive Guard (Impaler) (Impaler Cannon)",
+                  "Hive Guard (Shock) (Shockcannon)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Impaler Cannon"}),
+                  jasmine.objectContaining({'_name': "Shockcannon"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Carnifexes",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Carnifex"}),
+                ],
+                '_modelList': [
+                  "Carnifex (2x Monstrous Scything Talons)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Monstrous Scything Talons"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Exocrine",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Exocrine"}),
+                ],
+                '_modelList': [
+                  "Exocrine (Bio-plasmic Cannon, Powerful Limbs)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bio-plasmic Cannon"}),
+                  jasmine.objectContaining({'_name': "Powerful Limbs"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Exocrine (1)"}),
+                  jasmine.objectContaining({'_name': "Exocrine (2)"}),
+                  jasmine.objectContaining({'_name': "Exocrine (3)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Toxicrene",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Toxicrene"}),
+                ],
+                '_modelList': [
+                  "Toxicrene (Chocking Spores, Massive Toxic Lashes)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Choking Spores"}),
+                  jasmine.objectContaining({'_name': "Massive Toxic Lashes (Shooting)"}),
+                  jasmine.objectContaining({'_name': "Massive Toxic Lashes (Melee)"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Toxicrene (1)"}),
+                  jasmine.objectContaining({'_name': "Toxicrene (2)"}),
+                  jasmine.objectContaining({'_name': "Toxicrene (3)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Battle-forged CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Detachment CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Hive Fleet",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Stratagem: Bounty of the Hive Fleet",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Stratagem: Progeny of the Hive",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/XenosTestSpec.ts
+++ b/spec/XenosTestSpec.ts
@@ -12,155 +12,160 @@ describe("Create40kRoster", function() {
         '_points': 831,
         '_commandPoints': -2,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Big Mek [Legends]",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Big Mek"}),
-                jasmine.objectContaining({'_name': "Grot Oiler"}),
-              ],
-              '_modelList': [
-                "Grot Oiler (Slugga, Choppa, Stikkbombs)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Slugga"}),
-                jasmine.objectContaining({'_name': "Choppa"}),
-                jasmine.objectContaining({'_name': "Stikkbomb"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Weirdboy",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Weirdboy"}),
-              ],
-              '_modelList': [
-                "Weirdboy (Weirdboy Staff, 3. Da Jump)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Weirdboy Staff"}),
-              ],
-              '_spells': [
-                jasmine.objectContaining({'_name': "Smite"}),
-                jasmine.objectContaining({'_name': "Da Jump"}),
-              ],
-              '_psykers': [
-                jasmine.objectContaining({'_name': "Psyker"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Boyz",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Ork Boy"}),
-              ],
-              '_modelList': [
-                "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Slugga"}),
-                jasmine.objectContaining({'_name': "Choppa"}),
-                jasmine.objectContaining({'_name': "Stikkbomb"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Boyz",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Boss Nob"}),
-                jasmine.objectContaining({'_name': "Ork Boy"}),
-              ],
-              '_modelList': [
-                "Boss Nob (Slugga, Choppa, Stikkbombs)",
-                "2x Ork Boy W/ Shoota (Shoota, Stikkbombs)",
-                "8x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Shoota"}),
-                jasmine.objectContaining({'_name': "Slugga"}),
-                jasmine.objectContaining({'_name': "Choppa"}),
-                jasmine.objectContaining({'_name': "Stikkbomb"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Boyz",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Boss Nob"}),
-                jasmine.objectContaining({'_name': "Ork Boy"}),
-              ],
-              '_modelList': [
-                "Boss Nob (Slugga, Choppa, Stikkbombs)",
-                "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Slugga"}),
-                jasmine.objectContaining({'_name': "Choppa"}),
-                jasmine.objectContaining({'_name': "Stikkbomb"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Painboy on Warbike [Legends]",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Painboy on Warbike"}),
-              ],
-              '_modelList': [
-                "Painboy on Warbike [Legends] (2x Dakkagun, 'Urty Syringe, Killsaw, Super Cybork Body)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Dakkagun"}),
-                jasmine.objectContaining({'_name': "'Urty Syringe"}),
-                jasmine.objectContaining({'_name': "Killsaw"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Deff Dread Mob",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Deff Dread"}),
-              ],
-              '_modelList': [
-                "Deff Dread (2x Big Shoota, 2x Dread Klaw)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Big Shoota"}),
-                jasmine.objectContaining({'_name': "Dread Klaw"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Killa Kans",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Killa Kan"}),
-              ],
-              '_modelList': [
-                "Killa Kan (Big Shoota, Kan Klaw)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Big Shoota"}),
-                jasmine.objectContaining({'_name': "Kan Klaw"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Blitza-bommer",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Blitza-bommer"}),
-              ],
-              '_modelList': [
-                "Blitza-bommer (Big Shoota, 2x Supa Shoota, Boom Bomb)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Big Shoota"}),
-                jasmine.objectContaining({'_name': "Supa Shoota"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "BlitzaBom1"}),
-                jasmine.objectContaining({'_name': "BlitzaBom2"}),
-                jasmine.objectContaining({'_name': "BlitzaBom3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Dakkajet",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Dakkajet"}),
-              ],
-              '_modelList': [
-                "Dakkajet (4x Supa Shoota)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Supa Shoota"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Dakkajet1"}),
-                jasmine.objectContaining({'_name': "Dakkajet2"}),
-                jasmine.objectContaining({'_name': "Dakkajet3"}),
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [
+              "Clan Kultur: Bad Moons",
+            ],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Big Mek [Legends]",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Big Mek"}),
+                  jasmine.objectContaining({'_name': "Grot Oiler"}),
+                ],
+                '_modelList': [
+                  "Grot Oiler (Slugga, Choppa, Stikkbombs)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Slugga"}),
+                  jasmine.objectContaining({'_name': "Choppa"}),
+                  jasmine.objectContaining({'_name': "Stikkbomb"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Weirdboy",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Weirdboy"}),
+                ],
+                '_modelList': [
+                  "Weirdboy (Weirdboy Staff, 3. Da Jump)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Weirdboy Staff"}),
+                ],
+                '_spells': [
+                  jasmine.objectContaining({'_name': "Smite"}),
+                  jasmine.objectContaining({'_name': "Da Jump"}),
+                ],
+                '_psykers': [
+                  jasmine.objectContaining({'_name': "Psyker"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Boyz",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Ork Boy"}),
+                ],
+                '_modelList': [
+                  "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Slugga"}),
+                  jasmine.objectContaining({'_name': "Choppa"}),
+                  jasmine.objectContaining({'_name': "Stikkbomb"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Boyz",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Boss Nob"}),
+                  jasmine.objectContaining({'_name': "Ork Boy"}),
+                ],
+                '_modelList': [
+                  "Boss Nob (Slugga, Choppa, Stikkbombs)",
+                  "2x Ork Boy W/ Shoota (Shoota, Stikkbombs)",
+                  "8x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Shoota"}),
+                  jasmine.objectContaining({'_name': "Slugga"}),
+                  jasmine.objectContaining({'_name': "Choppa"}),
+                  jasmine.objectContaining({'_name': "Stikkbomb"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Boyz",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Boss Nob"}),
+                  jasmine.objectContaining({'_name': "Ork Boy"}),
+                ],
+                '_modelList': [
+                  "Boss Nob (Slugga, Choppa, Stikkbombs)",
+                  "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Slugga"}),
+                  jasmine.objectContaining({'_name': "Choppa"}),
+                  jasmine.objectContaining({'_name': "Stikkbomb"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Painboy on Warbike [Legends]",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Painboy on Warbike"}),
+                ],
+                '_modelList': [
+                  "Painboy on Warbike [Legends] (2x Dakkagun, 'Urty Syringe, Killsaw, Super Cybork Body)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Dakkagun"}),
+                  jasmine.objectContaining({'_name': "'Urty Syringe"}),
+                  jasmine.objectContaining({'_name': "Killsaw"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Deff Dread Mob",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Deff Dread"}),
+                ],
+                '_modelList': [
+                  "Deff Dread (2x Big Shoota, 2x Dread Klaw)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Big Shoota"}),
+                  jasmine.objectContaining({'_name': "Dread Klaw"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Killa Kans",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Killa Kan"}),
+                ],
+                '_modelList': [
+                  "Killa Kan (Big Shoota, Kan Klaw)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Big Shoota"}),
+                  jasmine.objectContaining({'_name': "Kan Klaw"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Blitza-bommer",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Blitza-bommer"}),
+                ],
+                '_modelList': [
+                  "Blitza-bommer (Big Shoota, 2x Supa Shoota, Boom Bomb)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Big Shoota"}),
+                  jasmine.objectContaining({'_name': "Supa Shoota"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "BlitzaBom1"}),
+                  jasmine.objectContaining({'_name': "BlitzaBom2"}),
+                  jasmine.objectContaining({'_name': "BlitzaBom3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Dakkajet",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Dakkajet"}),
+                ],
+                '_modelList': [
+                  "Dakkajet (4x Supa Shoota)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Supa Shoota"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Dakkajet1"}),
+                  jasmine.objectContaining({'_name': "Dakkajet2"}),
+                  jasmine.objectContaining({'_name': "Dakkajet3"}),
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/spec/helpers/40kRosterExpectation.ts
+++ b/spec/helpers/40kRosterExpectation.ts
@@ -30,56 +30,68 @@ describe("Create40kRoster", function() {
 
 function processForces(forces: Force[]): string {
   return forces.map(force => `
-          jasmine.objectContaining({'_units': [${processUnits(force._units)}
-          ]}),`).join('');
+          jasmine.objectContaining({
+            '_configurations': [${processConfigurations(force._configurations)}],
+            '_units': [${processUnits(force._units)}
+            ]
+          }),`).join('');
+}
+
+function processConfigurations(configurations: string[]): string {
+  if (configurations.length === 0) {
+    return '';
+  }
+  return configurations.map(config => `
+              ${JSON.stringify(config)},`).join('') + `
+            `;
 }
 
 function processUnits(units: Unit[]): string {
   return units.map(unit => `
-            jasmine.objectContaining({
-              '_name': ${JSON.stringify(unit._name)},
-              '_modelStats': [
-                ${processBaseNotes(unit._modelStats)}
-              ],
-              '_modelList': [
-                ${unit._modelList.map(e => JSON.stringify(e)).join(',\n                ')}
-              ],
-              '_weapons': [
-                ${processBaseNotes(unit._weapons)}
-              ]${processOptionalUnitStats(unit)}}),`).join('');
+              jasmine.objectContaining({
+                '_name': ${JSON.stringify(unit._name)},
+                '_modelStats': [
+                  ${processBaseNotes(unit._modelStats)}
+                ],
+                '_modelList': [
+                  ${unit._modelList.map(e => JSON.stringify(e)).join(',\n                  ')}
+                ],
+                '_weapons': [
+                  ${processBaseNotes(unit._weapons)}
+                ]${processOptionalUnitStats(unit)}}),`).join('');
 }
 
 function processBaseNotes(notes: BaseNotes[]) {
   return notes.map(note =>
     `jasmine.objectContaining({'_name': ${JSON.stringify(note._name)}}),`)
-    .join('\n                ');
+    .join('\n                  ');
 }
 
 function processOptionalUnitStats(unit: Unit) {
   let output = '';
   if (unit._spells.length > 0) {
     output += `,
-              '_spells': [
-                ${processBaseNotes(unit._spells)}
-              ]`
+                '_spells': [
+                  ${processBaseNotes(unit._spells)}
+                ]`
   }
   if (unit._psykers.length > 0) {
     output += `,
-              '_psykers': [
-                ${processBaseNotes(unit._psykers)}
-              ]`
+                '_psykers': [
+                  ${processBaseNotes(unit._psykers)}
+                ]`
   }
   if (unit._explosions.length > 0) {
     output += `,
-              '_explosions': [
-                ${processBaseNotes(unit._explosions)}
-              ]`
+                '_explosions': [
+                  ${processBaseNotes(unit._explosions)}
+                ]`
   }
   if (unit._woundTracker.length > 0) {
     output += `,
-              '_woundTracker': [
-                ${processBaseNotes(unit._woundTracker)}
-              ]`
+                '_woundTracker': [
+                  ${processBaseNotes(unit._woundTracker)}
+                ]`
   }
   return output;
 }

--- a/spec/helpers/printRosterStructure.ts
+++ b/spec/helpers/printRosterStructure.ts
@@ -7,13 +7,15 @@
 
 import { readZippedRosterFile } from './readRosterFile';
 
+let verbose = false;
+
 /**
  * Visits an Element node and its children, outputting useful bits to console.
  * @param el element to process
  * @param indent level to indent (increments by 1)
  */
 function visit(el: Element, indent = 0): void {
-  if (['categories', 'characteristics', 'publications'].includes(el.tagName)) {
+  if (!verbose && ['categories', 'characteristics', 'publications'].includes(el.tagName)) {
     return;
   } else if (el.children.length === 0 && el.attributes.length === 0) {
     return;
@@ -55,7 +57,7 @@ function visitCosts(el: Element, indent: number) {
 function visitPrintableElement(el: Element, indent: number) {
   const attrs = [];
   for (const attr of el.attributes) {
-    if (['id', 'publicationId', 'entryId', 'catalogueId', 'catalogueRevision',
+    if (!verbose && ['id', 'publicationId', 'entryId', 'catalogueId', 'catalogueRevision',
          'entryGroupId', 'typeId', 'page', 'hidden'].includes(attr.name)) {
         continue
     };
@@ -70,6 +72,12 @@ function printLine(el: Element, indent: number, details: string) {
 }
 
 async function main(args: string[]) {
+  const verboseFlagIndex = args.indexOf('-v');
+  if (verboseFlagIndex !== -1) {
+    args.splice(verboseFlagIndex, 1);
+    verbose = true;
+  }
+
   if (args.length !== 3) {
     console.error(`ERROR: Expected one CLI argument; got ${args.length}: ${args.join(' ')}`);
     return;

--- a/spec/helpers/write40kRosterExpectation.ts
+++ b/spec/helpers/write40kRosterExpectation.ts
@@ -3,6 +3,10 @@
  *
  * Run with:
  *   $ ts-node spec/helpers/write40kRosterExpectation.ts 'path/to/file'
+ *
+ * To update all 40k files, on a Mac:
+ *   $ smardan$ grep -l test/*.ros -E -e "Warhammer 40,000.*Edition" | tr \\n \\0 | xargs -0 ts-node spec/helpers/write40kRosterExpectation.ts
+ * (see https://stackoverflow.com/questions/16758525/make-xargs-handle-filenames-that-contain-spaces)
  */
 
 import fs from "fs";

--- a/spec/rosterSpec.ts
+++ b/spec/rosterSpec.ts
@@ -12,368 +12,374 @@ describe("Create40kRoster", function() {
         '_points': 1998,
         '_commandPoints': 8,
         '_forces': [
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Captain in Phobos Armour",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Captain in Phobos Armour"}),
-              ],
-              '_modelList': [
-                "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Frontline Commander, The Aurillian Shroud, Warlord)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Master-crafted instigator bolt carbine"}),
-                jasmine.objectContaining({'_name': "Combat knife"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "The Emperor's Champion",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Emperor's Champion"}),
-              ],
-              '_modelList': [
-                "The Emperor's Champion (Bolt pistol, Black Sword, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Black Sword"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Crusader Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Initiate"}),
-                jasmine.objectContaining({'_name': "Sword Brother"}),
-              ],
-              '_modelList': [
-                "4x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
-                "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Power fist"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Infiltrator Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Infiltrator"}),
-                jasmine.objectContaining({'_name': "Infiltrator Sergeant"}),
-              ],
-              '_modelList': [
-                "4x Infilltrator (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)",
-                "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Marksman bolt carbine"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Intercessor Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Intercessor"}),
-                jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
-              ],
-              '_modelList': [
-                "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag & Krak grenades)",
-                "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Stalker Bolt Rifle"}),
-                jasmine.objectContaining({'_name': "Thunder hammer"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Intercessor Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Intercessor"}),
-                jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
-              ],
-              '_modelList': [
-                "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag & Krak grenades)",
-                "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag & Krak grenades)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Stalker Bolt Rifle"}),
-                jasmine.objectContaining({'_name': "Thunder hammer"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Vanguard Veteran Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine Veteran (Jump Pack)"}),
-                jasmine.objectContaining({'_name': "Veteran Sergeant (Jump Pack)"}),
-              ],
-              '_modelList': [
-                "Vanguard Veteran Squad (Grav-pistol, Relic blade, 4x Thunder hammer, 5x Frag & Krak grenades, Jump Pack, Storm shield, Storm shield, Storm shield, Storm shield)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Grav-pistol"}),
-                jasmine.objectContaining({'_name': "Relic blade"}),
-                jasmine.objectContaining({'_name': "Thunder hammer"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Assault Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine (Jump Pack)"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
-              ],
-              '_modelList': [
-                "Assault Squad (2x Bolt pistol, 3x Plasma pistol, 4x Chainsword, 4x Frag & Krak grenades, Jump Pack)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Plasma pistol, Standard"}),
-                jasmine.objectContaining({'_name': "Plasma pistol, Supercharge"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Suppressor Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Suppressor"}),
-                jasmine.objectContaining({'_name': "Suppressor Sergeant"}),
-              ],
-              '_modelList': [
-                "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)",
-                "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Accelerator autocannon"}),
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Eliminator Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Eliminator"}),
-                jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
-              ],
-              '_modelList': [
-                "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)",
-                "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle - Executioner round"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle - Hyperfrag round"}),
-                jasmine.objectContaining({'_name': "Bolt sniper rifle - Mortis round"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "**Chapter Selection**",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Battle-forged CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Detachment CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
-          jasmine.objectContaining({'_units': [
-            jasmine.objectContaining({
-              '_name': "Chaplain Grimaldus",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Chaplain Grimaldus"}),
-              ],
-              '_modelList': [
-                "Chaplain Grimaldus (Plasma pistol, Artificer Crozius, Frag & Krak grenades, 1. Litany of Divine Protection, 5. Fervent Acclamation, Litany of Hate)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Plasma pistol, Standard"}),
-                jasmine.objectContaining({'_name': "Plasma pistol, Supercharge"}),
-                jasmine.objectContaining({'_name': "Artificer Crozius"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Aggressor Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Aggressor"}),
-                jasmine.objectContaining({'_name': "Aggressor Sergeant"}),
-              ],
-              '_modelList': [
-                "2x Aggressor (Auto Boltstorm Gauntlets, Fragstorm Grenade Launcher)",
-                "Aggressor Sergeant (Auto Boltstorm Gauntlets, Fragstorm Grenade Launcher)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Auto Boltstorm Gauntlets (Shooting)"}),
-                jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Auto Boltstorm Gauntlets (Melee)"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Redemptor Dreadnought",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought"}),
-              ],
-              '_modelList': [
-                "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Heavy flamer"}),
-                jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
-                jasmine.objectContaining({'_name': "Redemptor Fist"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought 1"}),
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought 2"}),
-                jasmine.objectContaining({'_name': "Redemptor Dreadnought 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Devastator Squad",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Space Marine"}),
-                jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
-              ],
-              '_modelList': [
-                "Devastator Squad (7x Bolt pistol, Boltgun, 4x Grav-cannon and grav-amp, Chainsword, 6x Frag & Krak grenades, Armorium Cherub)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Bolt pistol"}),
-                jasmine.objectContaining({'_name': "Boltgun"}),
-                jasmine.objectContaining({'_name': "Grav-cannon and grav-amp"}),
-                jasmine.objectContaining({'_name': "Chainsword"}),
-                jasmine.objectContaining({'_name': "Frag grenade"}),
-                jasmine.objectContaining({'_name': "Krak grenade"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Repulsor Executioner",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Repulsor Executioner"}),
-              ],
-              '_modelList': [
-                "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Laser Destroyer, Heavy Onslaught Gatling Cannon, Ironhail Heavy Stubber, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber, Auto Launchers)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
-                jasmine.objectContaining({'_name': "Heavy Laser Destroyer"}),
-                jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
-                jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-                jasmine.objectContaining({'_name': "Twin Heavy Bolter"}),
-                jasmine.objectContaining({'_name': "Twin Icarus Ironhail Heavy Stubber"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Repulsor Executioner 1"}),
-                jasmine.objectContaining({'_name': "Repulsor Executioner 2"}),
-                jasmine.objectContaining({'_name': "Repulsor Executioner 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Drop Pod",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Drop Pod"}),
-              ],
-              '_modelList': [
-                "Drop Pod (Storm bolter)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Impulsor",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Impulsor"}),
-              ],
-              '_modelList': [
-                "Impulsor (Ironhail Heavy Stubber, Ironhail Skytalon Array, 2x Storm Bolters)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
-                jasmine.objectContaining({'_name': "Ironhail Sytalon Array"}),
-                jasmine.objectContaining({'_name': "Storm bolter"}),
-              ],
-              '_woundTracker': [
-                jasmine.objectContaining({'_name': "Impulsor Wound Track 1"}),
-                jasmine.objectContaining({'_name': "Impulsor Wound Track 2"}),
-                jasmine.objectContaining({'_name': "Impulsor Wound Track 3"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "**Chapter Selection**",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Cenobyte Servitors",
-              '_modelStats': [
-                jasmine.objectContaining({'_name': "Cenobyte Servitors"}),
-              ],
-              '_modelList': [
-                "Cenobyte Servitors (3x Close Combat Weapon)"
-              ],
-              '_weapons': [
-                jasmine.objectContaining({'_name': "Close Combat Weapon"}),
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Detachment CP",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-            jasmine.objectContaining({
-              '_name': "Relics of the Chapter",
-              '_modelStats': [
-                
-              ],
-              '_modelList': [
-                
-              ],
-              '_weapons': [
-                
-              ]}),
-          ]}),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Captain in Phobos Armour",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Captain in Phobos Armour"}),
+                ],
+                '_modelList': [
+                  "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Frontline Commander, The Aurillian Shroud, Warlord)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Master-crafted instigator bolt carbine"}),
+                  jasmine.objectContaining({'_name': "Combat knife"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "The Emperor's Champion",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Emperor's Champion"}),
+                ],
+                '_modelList': [
+                  "The Emperor's Champion (Bolt pistol, Black Sword, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Black Sword"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Crusader Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Initiate"}),
+                  jasmine.objectContaining({'_name': "Sword Brother"}),
+                ],
+                '_modelList': [
+                  "4x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
+                  "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Power fist"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Infiltrator Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Infiltrator"}),
+                  jasmine.objectContaining({'_name': "Infiltrator Sergeant"}),
+                ],
+                '_modelList': [
+                  "4x Infilltrator (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)",
+                  "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Marksman bolt carbine"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Intercessor Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Intercessor"}),
+                  jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
+                ],
+                '_modelList': [
+                  "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag & Krak grenades)",
+                  "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Stalker Bolt Rifle"}),
+                  jasmine.objectContaining({'_name': "Thunder hammer"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Intercessor Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Intercessor"}),
+                  jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
+                ],
+                '_modelList': [
+                  "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag & Krak grenades)",
+                  "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag & Krak grenades)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Stalker Bolt Rifle"}),
+                  jasmine.objectContaining({'_name': "Thunder hammer"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Vanguard Veteran Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine Veteran (Jump Pack)"}),
+                  jasmine.objectContaining({'_name': "Veteran Sergeant (Jump Pack)"}),
+                ],
+                '_modelList': [
+                  "Vanguard Veteran Squad (Grav-pistol, Relic blade, 4x Thunder hammer, 5x Frag & Krak grenades, Jump Pack, Storm shield, Storm shield, Storm shield, Storm shield)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Grav-pistol"}),
+                  jasmine.objectContaining({'_name': "Relic blade"}),
+                  jasmine.objectContaining({'_name': "Thunder hammer"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Assault Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine (Jump Pack)"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
+                ],
+                '_modelList': [
+                  "Assault Squad (2x Bolt pistol, 3x Plasma pistol, 4x Chainsword, 4x Frag & Krak grenades, Jump Pack)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Plasma pistol, Standard"}),
+                  jasmine.objectContaining({'_name': "Plasma pistol, Supercharge"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Suppressor Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Suppressor"}),
+                  jasmine.objectContaining({'_name': "Suppressor Sergeant"}),
+                ],
+                '_modelList': [
+                  "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)",
+                  "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Accelerator autocannon"}),
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Eliminator Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Eliminator"}),
+                  jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
+                ],
+                '_modelList': [
+                  "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)",
+                  "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle - Executioner round"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle - Hyperfrag round"}),
+                  jasmine.objectContaining({'_name': "Bolt sniper rifle - Mortis round"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "**Chapter Selection**",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Battle-forged CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Detachment CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
+          jasmine.objectContaining({
+            '_configurations': [],
+            '_units': [
+              jasmine.objectContaining({
+                '_name': "Chaplain Grimaldus",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Chaplain Grimaldus"}),
+                ],
+                '_modelList': [
+                  "Chaplain Grimaldus (Plasma pistol, Artificer Crozius, Frag & Krak grenades, 1. Litany of Divine Protection, 5. Fervent Acclamation, Litany of Hate)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Plasma pistol, Standard"}),
+                  jasmine.objectContaining({'_name': "Plasma pistol, Supercharge"}),
+                  jasmine.objectContaining({'_name': "Artificer Crozius"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Aggressor Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Aggressor"}),
+                  jasmine.objectContaining({'_name': "Aggressor Sergeant"}),
+                ],
+                '_modelList': [
+                  "2x Aggressor (Auto Boltstorm Gauntlets, Fragstorm Grenade Launcher)",
+                  "Aggressor Sergeant (Auto Boltstorm Gauntlets, Fragstorm Grenade Launcher)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Auto Boltstorm Gauntlets (Shooting)"}),
+                  jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Auto Boltstorm Gauntlets (Melee)"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Redemptor Dreadnought",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought"}),
+                ],
+                '_modelList': [
+                  "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Heavy flamer"}),
+                  jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
+                  jasmine.objectContaining({'_name': "Redemptor Fist"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought 1"}),
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought 2"}),
+                  jasmine.objectContaining({'_name': "Redemptor Dreadnought 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Devastator Squad",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Space Marine"}),
+                  jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
+                ],
+                '_modelList': [
+                  "Devastator Squad (7x Bolt pistol, Boltgun, 4x Grav-cannon and grav-amp, Chainsword, 6x Frag & Krak grenades, Armorium Cherub)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Bolt pistol"}),
+                  jasmine.objectContaining({'_name': "Boltgun"}),
+                  jasmine.objectContaining({'_name': "Grav-cannon and grav-amp"}),
+                  jasmine.objectContaining({'_name': "Chainsword"}),
+                  jasmine.objectContaining({'_name': "Frag grenade"}),
+                  jasmine.objectContaining({'_name': "Krak grenade"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Repulsor Executioner",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Repulsor Executioner"}),
+                ],
+                '_modelList': [
+                  "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Laser Destroyer, Heavy Onslaught Gatling Cannon, Ironhail Heavy Stubber, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber, Auto Launchers)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
+                  jasmine.objectContaining({'_name': "Heavy Laser Destroyer"}),
+                  jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),
+                  jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                  jasmine.objectContaining({'_name': "Twin Heavy Bolter"}),
+                  jasmine.objectContaining({'_name': "Twin Icarus Ironhail Heavy Stubber"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Repulsor Executioner 1"}),
+                  jasmine.objectContaining({'_name': "Repulsor Executioner 2"}),
+                  jasmine.objectContaining({'_name': "Repulsor Executioner 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Drop Pod",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Drop Pod"}),
+                ],
+                '_modelList': [
+                  "Drop Pod (Storm bolter)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Impulsor",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Impulsor"}),
+                ],
+                '_modelList': [
+                  "Impulsor (Ironhail Heavy Stubber, Ironhail Skytalon Array, 2x Storm Bolters)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),
+                  jasmine.objectContaining({'_name': "Ironhail Sytalon Array"}),
+                  jasmine.objectContaining({'_name': "Storm bolter"}),
+                ],
+                '_woundTracker': [
+                  jasmine.objectContaining({'_name': "Impulsor Wound Track 1"}),
+                  jasmine.objectContaining({'_name': "Impulsor Wound Track 2"}),
+                  jasmine.objectContaining({'_name': "Impulsor Wound Track 3"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "**Chapter Selection**",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Cenobyte Servitors",
+                '_modelStats': [
+                  jasmine.objectContaining({'_name': "Cenobyte Servitors"}),
+                ],
+                '_modelList': [
+                  "Cenobyte Servitors (3x Close Combat Weapon)"
+                ],
+                '_weapons': [
+                  jasmine.objectContaining({'_name': "Close Combat Weapon"}),
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Detachment CP",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+              jasmine.objectContaining({
+                '_name': "Relics of the Chapter",
+                '_modelStats': [
+                  
+                ],
+                '_modelList': [
+                  
+                ],
+                '_weapons': [
+                  
+                ]}),
+            ]
+          }),
         ]}));
   });
 });

--- a/src/roster40k.ts
+++ b/src/roster40k.ts
@@ -475,10 +475,11 @@ function ParseSelections(root: Element, force: Force, is40k: boolean): void {
 }
 
 function ParseConfiguration(selection: Element, force: Force) {
-    let configuration = selection.getAttribute("name");
-    if (!configuration || !selection.querySelector("category[name='Configuration']")) {
+    const name = selection.getAttribute("name");
+    if (!name) {
         return;
     }
+    const category = selection.querySelector("category")?.getAttribute('name');
     const subSelections = selection.querySelectorAll('selections>selection');
     const details = [];
     let cpCost = 0;
@@ -487,8 +488,10 @@ function ParseConfiguration(selection: Element, force: Force) {
         cpCost += GetSelectionCp(sel);
     }
 
+    let configuration = (!category || category === 'Configuration')
+        ? name : `${category} - ${name}`;
     if (details.length > 0) configuration += `: ${details.join(", ")}`;
-    if (cpCost > 0) configuration += ` [${cpCost} CP]`;
+    if (cpCost !== 0) configuration += ` [${cpCost} CP]`;
 
     force._configurations.push(configuration);
 }


### PR DESCRIPTION
For 40k, make sure stratagems (and other non-unit upgrades) show up in the roster summary.

Update tests to include these configurations.

Add a -v verbose flag to printRosterStructure