### PR TITLE
40k: fix missing unit upgrades, list more costs

### DIFF
--- a/spec/AeldariTestSpec.ts
+++ b/spec/AeldariTestSpec.ts
@@ -56,7 +56,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Dire Avenger"}),
                 ],
                 '_modelList': [
-                  "5x Dire Avenger (Avenger Shuriken Catapult, Plasma Grenades)"
+                  "5x Dire Avenger (Avenger Shuriken Catapult, Plasma Grenades)",
+                  "Unit Upgrades (Defence Tactics)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Avenger Shuriken Catapult"}),
@@ -69,7 +70,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Ranger"}),
                 ],
                 '_modelList': [
-                  "5x Ranger (Ranger Long Rifle, Shuriken Pistol)"
+                  "5x Ranger (Ranger Long Rifle, Shuriken Pistol)",
+                  "Unit Upgrades (Appear Unbidden, Cameleoline Cloaks)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Ranger Long Rifle"}),

--- a/spec/BlackTemplar2000Spec.ts
+++ b/spec/BlackTemplar2000Spec.ts
@@ -87,7 +87,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Infilltrator (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)",
-                  "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)"
+                  "Infiltrator Sergeant (Bolt pistol, Marksman bolt carbine, Frag & Krak grenades)",
+                  "Unit Upgrades (Infiltrator Comms Array [10 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -104,7 +105,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
-                  "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)"
+                  "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)",
+                  "Unit Upgrades (Auxiliary Grenade Launcher [1 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Auto Bolt Rifle"}),
@@ -122,7 +124,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
-                  "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)"
+                  "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)",
+                  "Unit Upgrades (Auxiliary Grenade Launcher [1 pts], Veteran Intercessors [-1 CP])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Auto Bolt Rifle"}),

--- a/spec/ChaosSMTestSpec.ts
+++ b/spec/ChaosSMTestSpec.ts
@@ -81,7 +81,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "9x Chaos Cultist w/ Autogun (Autogun)",
-                  "Cultist Champion (Autogun)"
+                  "Cultist Champion (Autogun)",
+                  "Unit Upgrades (No Chaos Mark)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Autogun"}),
@@ -95,7 +96,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "Aspiring Champion (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                  "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)"
+                  "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Unit Upgrades (No Chaos Mark)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -112,7 +114,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "Aspiring Champion (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                  "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)"
+                  "4x Marine w/ Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)",
+                  "Unit Upgrades (No Chaos Mark)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -129,7 +132,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "Chaos Terminator Champion (Combi-bolter, Chainaxe)",
-                  "4x Terminator (Combi-bolter, Chainaxe)"
+                  "4x Terminator (Combi-bolter, Chainaxe)",
+                  "Unit Upgrades (Icon of Vengeance [5 pts], No Chaos Mark)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Combi-bolter"}),
@@ -142,7 +146,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Mutilator"}),
                 ],
                 '_modelList': [
-                  "3x Mutilator (Fleshmetal weapons)"
+                  "3x Mutilator (Fleshmetal weapons)",
+                  "Unit Upgrades (No Chaos Mark)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Fleshmetal weapons"}),
@@ -171,7 +176,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Possessed"}),
                 ],
                 '_modelList': [
-                  "5x Possessed (Horrifying Mutations)"
+                  "5x Possessed (Horrifying Mutations)",
+                  "Unit Upgrades (No Chaos Mark)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Horrifying Mutations"}),
@@ -183,7 +189,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Chaos Spawn"}),
                 ],
                 '_modelList': [
-                  "Chaos Spawn (Hideous mutations)"
+                  "Chaos Spawn (Hideous mutations)",
+                  "Unit Upgrades (No Chaos Mark)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Hideous mutations"}),
@@ -195,7 +202,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Obliterator"}),
                 ],
                 '_modelList': [
-                  "Obliterator (Fleshmetal guns, Crushing fists)"
+                  "Obliterator (Fleshmetal guns, Crushing fists)",
+                  "Unit Upgrades (No Chaos Mark)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Fleshmetal guns"}),
@@ -251,7 +259,7 @@ describe("Create40kRoster", function() {
                   
                 ],
                 '_modelList': [
-                  
+                  "Unit Upgrades (Renegade Chapters)"
                 ],
                 '_weapons': [
                   

--- a/spec/DeathGuardand1000SonsSpec.ts
+++ b/spec/DeathGuardand1000SonsSpec.ts
@@ -136,7 +136,8 @@ describe("Create40kRoster", function() {
                   "Aspiring Sorcerer (Plasma pistol, Force sword, Glamour of Tzeentch, Smite)",
                   "8x Rubric Marine w/ Inferno Boltgun (Inferno boltgun)",
                   "Rubric Marine w/ Soulreaper cannon (Soulreaper cannon)",
-                  "Rubric Marine w/ Warpflamer (Warpflamer)"
+                  "Rubric Marine w/ Warpflamer (Warpflamer)",
+                  "Unit Upgrades (Icon of Flame [5 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Inferno boltgun"}),
@@ -182,7 +183,8 @@ describe("Create40kRoster", function() {
                 '_modelList': [
                   "Twistbray (Tzaangor blades)",
                   "8x Tzaangor w/ Tzaangor Blades (Tzaangor blades)",
-                  "Tzaangor w/ autopistol and chainsword (Autopistol, Chainsword)"
+                  "Tzaangor w/ autopistol and chainsword (Autopistol, Chainsword)",
+                  "Unit Upgrades (Brayhorn [10 pts], Icon of Flame [5 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Autopistol"}),

--- a/spec/GuardSpec.ts
+++ b/spec/GuardSpec.ts
@@ -307,6 +307,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Wyvern"}),
                 ],
                 '_modelList': [
+                  "Unit Upgrades (Stat Damage (HS))",
                   "Wyvern (Heavy Bolter, Wyven Quad Stormshard Mortar)"
                 ],
                 '_weapons': [

--- a/spec/KnightsSpec.ts
+++ b/spec/KnightsSpec.ts
@@ -138,7 +138,7 @@ describe("Create40kRoster", function() {
                   
                 ],
                 '_modelList': [
-                  
+                  "Unit Upgrades (House Griffith, Questor Imperialis)"
                 ],
                 '_weapons': [
                   

--- a/spec/TauTestSpec.ts
+++ b/spec/TauTestSpec.ts
@@ -270,7 +270,8 @@ describe("Create40kRoster", function() {
                 '_modelList': [
                   "MV4 Shield Drone (Shield generator)",
                   "4x Stealth Shas'ui w/ Burst Cannon (Burst cannon)",
-                  "Stealth Shas'vre (Burst cannon)"
+                  "Stealth Shas'vre (Burst cannon)",
+                  "Unit Upgrades (Homing beacon [20 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Burst cannon"}),

--- a/spec/TyranidsTestSpec.ts
+++ b/spec/TyranidsTestSpec.ts
@@ -273,7 +273,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "3x Hive Guard (Impaler) (Impaler Cannon)",
-                  "Hive Guard (Shock) (Shockcannon)"
+                  "Hive Guard (Shock) (Shockcannon)",
+                  "Unit Upgrades (Adrenal Glands [4 pts], Toxin Sacs [4 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Impaler Cannon"}),
@@ -359,7 +360,7 @@ describe("Create40kRoster", function() {
                   
                 ],
                 '_modelList': [
-                  
+                  "Unit Upgrades (Hydra)"
                 ],
                 '_weapons': [
                   
@@ -371,7 +372,7 @@ describe("Create40kRoster", function() {
                   
                 ],
                 '_modelList': [
-                  
+                  "Unit Upgrades (1 Extra Bio-artefact [-1 CP])"
                 ],
                 '_weapons': [
                   

--- a/spec/XenosTestSpec.ts
+++ b/spec/XenosTestSpec.ts
@@ -23,7 +23,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Grot Oiler"}),
                 ],
                 '_modelList': [
-                  "Grot Oiler (Slugga, Choppa, Stikkbombs)"
+                  "Grot Oiler (Slugga, Choppa, Stikkbombs)",
+                  "Unit Upgrades (Ard as Nails, Warlord)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Slugga"}),
@@ -90,7 +91,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "Boss Nob (Slugga, Choppa, Stikkbombs)",
-                  "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)"
+                  "10x Ork Boy W/ Slugga & Choppa (Slugga, Choppa, Stikkbombs)",
+                  "Unit Upgrades ('Ard Boyz [-2 CP])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Slugga"}),

--- a/src/renderer40k.ts
+++ b/src/renderer40k.ts
@@ -70,6 +70,10 @@ export class Renderer40k implements Renderer {
     private renderRosterSummary(list: HTMLElement) {
         if (!this._roster) return;
 
+        // Only add units' CP costs if at least one unit has CP values. This
+        // saves horizontal space for rosters that don't spend CP on units.
+        const unitsHaveCpCost = this._roster._forces.some(f => f._units.some(u => u._cost._commandPoints !== 0));
+
         for (const force of this._roster._forces) {
 
             const forceTitle = document.createElement('div');
@@ -96,6 +100,9 @@ export class Renderer40k implements Renderer {
             const tr = document.createElement('tr');
             thead.appendChild(tr);
             const headerInfo = [{ name: "NAME", w: '20%' }, { name: "ROLE", w: '15%' }, { name: "MODELS", w: '55%' }, { name: "POINTS", w: '5%' }, { name: "POWER", w: '5%' }];
+            if (unitsHaveCpCost) {
+                headerInfo.push({name: "CP", w: '5%'});
+            }
             headerInfo.forEach(element => {
                 let th = document.createElement('th');
                 th.scope = "col";
@@ -119,6 +126,10 @@ export class Renderer40k implements Renderer {
                 }
                 tr.appendChild(document.createElement('td')).appendChild(document.createTextNode(unit._cost._points.toString()));
                 tr.appendChild(document.createElement('td')).appendChild(document.createTextNode(unit._cost._powerLevel.toString()));
+                if (unitsHaveCpCost) {
+                    const commandPointsString = (unit._cost._commandPoints || '') + '';
+                    tr.appendChild(document.createElement('td')).appendChild(document.createTextNode(commandPointsString));
+                }
                 body.appendChild(tr);
             }
         }


### PR DESCRIPTION
Some unit upgrades were missing for 40k lists. Specifically, selections that were at the root level for a unit. Add the costs for those upgrades too.

While we're at it, add CP cost to the roster summary, but only when the roster contains units with CP costs