### PR TITLE
40k: toggle weapon/upgrade costs on/off

### DIFF
--- a/spec/AeldariTestSpec.ts
+++ b/spec/AeldariTestSpec.ts
@@ -145,7 +145,11 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Crimson Hunter Exarch 2."}),
                   jasmine.objectContaining({'_name': "Crimson Hunter Exarch 3."}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map(),
+            '_factionRules': new Map([
+              ["Alaitoc: Fieldcraft", jasmine.any(String)],
+            ]),
           }),
           jasmine.objectContaining({
             '_configurations': [
@@ -320,7 +324,14 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Twin splinter rifle"}),
                   jasmine.objectContaining({'_name': "Bladevanes"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Poisoned Weapon", jasmine.any(String)],
+              ["Power from Pain", jasmine.any(String)],
+              ["Vanguard of the Dark City", jasmine.any(String)],
+              ["Combat Drugs", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/AeldariTestSpec.ts
+++ b/spec/AeldariTestSpec.ts
@@ -56,7 +56,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Dire Avenger"}),
                 ],
                 '_modelList': [
-                  "5x Dire Avenger (Avenger Shuriken Catapult, Plasma Grenades)",
+                  "5x Dire Avenger (Avenger Shuriken Catapult [3 pts], Plasma Grenades)",
                   "Unit Upgrades (Defence Tactics)"
                 ],
                 '_weapons': [
@@ -116,7 +116,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Crimson Hunter"}),
                 ],
                 '_modelList': [
-                  "Crimson Hunter (2x Bright Lance, Pulse Laser, Airborne, Crash and Burn, Hard to Hit, Skyhunters, Wings of Khaine)"
+                  "Crimson Hunter (2x Bright Lance [40 pts], Pulse Laser, Airborne, Crash and Burn, Hard to Hit, Skyhunters, Wings of Khaine)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bright Lance"}),
@@ -134,7 +134,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Crimson Hunter Exarch"}),
                 ],
                 '_modelList': [
-                  "Crimson Hunter Exarch (Two Bright Lances, Pulse Laser, Airborne, Crash and Burn, Hard to Hit, Marksman's Eye, Skyhunters, Wings of Khaine)"
+                  "Crimson Hunter Exarch (Two Bright Lances [40 pts], Pulse Laser, Airborne, Crash and Burn, Hard to Hit, Marksman's Eye, Skyhunters, Wings of Khaine)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bright Lance"}),
@@ -264,7 +264,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Ravager"}),
                 ],
                 '_modelList': [
-                  "Ravager (3x Dark Lance, Bladevanes, Night Shield)"
+                  "Ravager (3x Dark Lance [45 pts], Bladevanes, Night Shield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Dark Lance"}),
@@ -304,7 +304,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Talos"}),
                 ],
                 '_modelList': [
-                  "Talos (2x Splinter Cannon, 2x Macro-Scalpel)"
+                  "Talos (2x Splinter Cannon [20 pts], 2x Macro-Scalpel [8 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Splinter Cannon"}),
@@ -317,7 +317,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Venom"}),
                 ],
                 '_modelList': [
-                  "Venom (Splinter Cannon, Twin splinter rifle, Bladevanes, Flickerfield, Night Shield)"
+                  "Venom (Splinter Cannon [10 pts], Twin splinter rifle, Bladevanes, Flickerfield, Night Shield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Splinter Cannon"}),

--- a/spec/AeldariTestSpec.ts
+++ b/spec/AeldariTestSpec.ts
@@ -13,8 +13,8 @@ describe("Create40kRoster", function() {
           jasmine.objectContaining({
             '_configurations': [
               "Faction: <Craftworld> - Craftworld Attribute: Alaitoc: Fieldcraft",
-              "Battle-forged CP",
-              "Detachment CP",
+              "Battle-forged CP [3 CP]",
+              "Detachment CP [5 CP]",
             ],
             '_units': [
               jasmine.objectContaining({
@@ -154,7 +154,7 @@ describe("Create40kRoster", function() {
           jasmine.objectContaining({
             '_configurations': [
               "Detachment Type: Mixed Detachment",
-              "Detachment CP",
+              "Detachment CP [1 CP]",
             ],
             '_units': [
               jasmine.objectContaining({

--- a/spec/BlackTemplar-TestOutputSpec.ts
+++ b/spec/BlackTemplar-TestOutputSpec.ts
@@ -11,7 +11,9 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 124, _points: 2087, _commandPoints: -3}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - **Chapter Selection**: Black Templars",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Chapter Master in Phobos Armor",
@@ -96,29 +98,20 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Frag grenade"}),
                   jasmine.objectContaining({'_name': "Krak grenade"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "**Chapter Selection**",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
             '_rules': new Map([
               ["Bolter Discipline", jasmine.any(String)],
               ["Angels of Death", jasmine.any(String)],
               ["Shock Assault", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
               ["Righteous Zeal", jasmine.any(String)],
             ]),
-            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - **Chapter Selection**: Black Templars",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Chaplain Grimaldus",
@@ -222,27 +215,18 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Frag grenade"}),
                   jasmine.objectContaining({'_name': "Krak grenade"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "**Chapter Selection**",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
             '_rules': new Map([
-              ["Righteous Zeal", jasmine.any(String)],
               ["Angels of Death", jasmine.any(String)],
             ]),
-            '_factionRules': new Map(),
+            '_factionRules': new Map([
+              ["Righteous Zeal", jasmine.any(String)],
+            ]),
           }),
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - **Chapter Selection**: Black Templars",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Lieutenants in Phobos Armor",
@@ -373,25 +357,14 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Repulsor 2"}),
                   jasmine.objectContaining({'_name': "Repulsor 3"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "**Chapter Selection**",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
             '_rules': new Map([
-              ["Righteous Zeal", jasmine.any(String)],
               ["Angels of Death", jasmine.any(String)],
               ["Explodes (6\"/D6)", jasmine.any(String)],
             ]),
-            '_factionRules': new Map(),
+            '_factionRules': new Map([
+              ["Righteous Zeal", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/BlackTemplar-TestOutputSpec.ts
+++ b/spec/BlackTemplar-TestOutputSpec.ts
@@ -54,7 +54,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Scout Sergeant"}),
                 ],
                 '_modelList': [
-                  "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag & Krak grenades)"
+                  "Scout Squad (5x Bolt pistol, 5x Boltgun, 5x Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),

--- a/spec/BlackTemplar-TestOutputSpec.ts
+++ b/spec/BlackTemplar-TestOutputSpec.ts
@@ -108,7 +108,14 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Bolter Discipline", jasmine.any(String)],
+              ["Angels of Death", jasmine.any(String)],
+              ["Shock Assault", jasmine.any(String)],
+              ["Righteous Zeal", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [],
@@ -227,7 +234,12 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Righteous Zeal", jasmine.any(String)],
+              ["Angels of Death", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [],
@@ -373,7 +385,13 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Righteous Zeal", jasmine.any(String)],
+              ["Angels of Death", jasmine.any(String)],
+              ["Explodes (6\"/D6)", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/BlackTemplar-TestOutputSpec.ts
+++ b/spec/BlackTemplar-TestOutputSpec.ts
@@ -22,7 +22,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Chapter Master in Phobos Armor (Stratagem: Chapter Master)"}),
                 ],
                 '_modelList': [
-                  "Chapter Master in Phobos Armor (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Frontline Commander, Stratagem: Chapter Master [-2 CP], Stratagem: Hero of the Chapter [-1 CP])"
+                  "Chapter Master in Phobos Armor (Bolt pistol, Master-crafted instigator bolt carbine [6 pts], Combat knife, Frag & Krak grenades, Camo cloak [3 pts], Frontline Commander, Stratagem: Chapter Master [-2 CP], Stratagem: Hero of the Chapter [-1 CP])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -38,7 +38,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Primaris Lieutenants"}),
                 ],
                 '_modelList': [
-                  "Primaris Lieutenants (Bolt pistol, Master-crafted auto bolt rifle, Frag & Krak grenades)"
+                  "Primaris Lieutenants (Bolt pistol, Master-crafted auto bolt rifle [4 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -70,8 +70,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
                 ],
                 '_modelList': [
-                  "6x Space Marine (7x Bolt pistol, Boltgun, Grav-gun, 7x Frag & Krak grenades)",
-                  "Space Marine Sergeant (2x Bolt pistol, Boltgun, Grav-gun, 2x Frag & Krak grenades, Melta bombs)"
+                  "6x Space Marine (7x Bolt pistol, Boltgun, Grav-gun [10 pts], 7x Frag & Krak grenades)",
+                  "Space Marine Sergeant (2x Bolt pistol, Boltgun, Grav-gun [10 pts], 2x Frag & Krak grenades, Melta bombs [5 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -153,8 +153,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "3x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
-                  "Initiate w/Heavy or Melee Weapon (Bolt pistol, Lascannon, Frag & Krak grenades)",
-                  "Sword Brother (Bolt pistol, Power axe, Frag & Krak grenades)"
+                  "Initiate w/Heavy or Melee Weapon (Bolt pistol, Lascannon [25 pts], Frag & Krak grenades)",
+                  "Sword Brother (Bolt pistol, Power axe [5 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -174,9 +174,9 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                  "Initiate w/Special Weapon (Bolt pistol, Grav-gun, Frag & Krak grenades)",
+                  "Initiate w/Special Weapon (Bolt pistol, Grav-gun [10 pts], Frag & Krak grenades)",
                   "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag & Krak grenades)",
-                  "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
+                  "Sword Brother (Bolt pistol, Power fist [9 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Astartes shotgun"}),
@@ -198,11 +198,11 @@ describe("Create40kRoster", function() {
                 '_modelList': [
                   "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
                   "Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
-                  "Initiate w/Heavy or Melee Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
+                  "Initiate w/Heavy or Melee Weapon (Bolt pistol, Heavy bolter [10 pts], Frag & Krak grenades)",
                   "Neophyte w/Boltgun (Bolt pistol, Boltgun, Frag & Krak grenades)",
                   "Neophyte w/Combat Knife (Bolt pistol, Combat knife, Frag & Krak grenades)",
                   "Neophyte w/Shotgun (Astartes shotgun, Bolt pistol, Frag & Krak grenades)",
-                  "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
+                  "Sword Brother (Bolt pistol, Power fist [9 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Astartes shotgun"}),
@@ -235,7 +235,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
                 ],
                 '_modelList': [
-                  "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag & Krak grenades, Grav-chute)"
+                  "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle [4 pts], Paired Combat Blades, Frag & Krak grenades, Grav-chute [2 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -252,7 +252,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Centurion Sergeant"}),
                 ],
                 '_modelList': [
-                  "Centurion Devastator Squad (3x Two Heavy Bolters, 3x Hurricane bolter)"
+                  "Centurion Devastator Squad (3x Two Heavy Bolters [60 pts], 3x Hurricane bolter [30 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy bolter"}),
@@ -266,7 +266,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
                 ],
                 '_modelList': [
-                  "Devastator Squad (5x Bolt pistol, Grav-cannon and grav-amp, Grav-pistol, 2x Heavy bolter, Multi-melta, Chainsword, 5x Frag & Krak grenades)"
+                  "Devastator Squad (5x Bolt pistol, Grav-cannon and grav-amp [20 pts], Grav-pistol [8 pts], 2x Heavy bolter [20 pts], Multi-melta [22 pts], Chainsword, 5x Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -286,8 +286,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
                 ],
                 '_modelList': [
-                  "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)",
-                  "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)"
+                  "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle [3 pts], Frag & Krak grenades, Camo cloak [3 pts])",
+                  "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle [3 pts], Frag & Krak grenades, Camo cloak [3 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -305,7 +305,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Repulsor Executioner"}),
                 ],
                 '_modelList': [
-                  "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Icarus Rocket Pod, Ironhail Heavy Stubber, Macro Plasma Incinerator, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber, Auto Launchers)"
+                  "Repulsor Executioner (2x Fragstorm Grenade Launcher [8 pts], Heavy Onslaught Gatling Cannon [30 pts], Icarus Rocket Pod [6 pts], Ironhail Heavy Stubber [6 pts], Macro Plasma Incinerator [31 pts], 2x Storm bolter [4 pts], Twin Heavy Bolter [17 pts], Twin Icarus Ironhail Heavy Stubber [10 pts], Auto Launchers)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
@@ -330,7 +330,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Drop Pod"}),
                 ],
                 '_modelList': [
-                  "Drop Pod (Storm bolter)"
+                  "Drop Pod (Storm bolter [2 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -342,7 +342,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Repulsor"}),
                 ],
                 '_modelList': [
-                  "Repulsor (Heavy Onslaught Gatling Cannon, Icarus Ironhail Heavy Stubber, 2x Ironhail Heavy Stubber, 2x Krakstorm Grenade Launcher, 2x Storm Bolters, Twin heavy bolter, Auto Launchers)"
+                  "Repulsor (Heavy Onslaught Gatling Cannon [30 pts], Icarus Ironhail Heavy Stubber [6 pts], 2x Ironhail Heavy Stubber [12 pts], 2x Krakstorm Grenade Launcher [8 pts], 2x Storm Bolters [4 pts], Twin heavy bolter [17 pts], Auto Launchers)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy Onslaught Gatling Cannon"}),

--- a/spec/BlackTemplar2000Spec.ts
+++ b/spec/BlackTemplar2000Spec.ts
@@ -24,7 +24,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Captain in Phobos Armour"}),
                 ],
                 '_modelList': [
-                  "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Champion of Humanity, Warlord)"
+                  "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine [6 pts], Combat knife, Frag & Krak grenades, Camo cloak [3 pts], Champion of Humanity, Warlord)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -40,7 +40,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Lieutenant in Phobos Armour"}),
                 ],
                 '_modelList': [
-                  "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle, Paired Combat Blades, Frag & Krak grenades, Grav-chute, The Armour Indomitus)"
+                  "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt rifle [4 pts], Paired Combat Blades, Frag & Krak grenades, Grav-chute [2 pts], The Armour Indomitus)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -73,7 +73,7 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Initiate (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                  "Sword Brother (Boltgun, Power fist, Frag & Krak grenades)"
+                  "Sword Brother (Boltgun, Power fist [9 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -108,8 +108,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Intercessor Sergeant"}),
                 ],
                 '_modelList': [
-                  "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
-                  "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)",
+                  "4x Intercessor (Auto Bolt Rifle [5 pts], Bolt pistol, Frag & Krak grenades)",
+                  "Intercessor Sergeant (Auto Bolt Rifle [5 pts], Bolt pistol, Thunder hammer [16 pts], Frag & Krak grenades)",
                   "Unit Upgrades (Auxiliary Grenade Launcher [1 pts])"
                 ],
                 '_weapons': [
@@ -127,8 +127,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Intercessor Sergeant (Veteran Intercessors)"}),
                 ],
                 '_modelList': [
-                  "4x Intercessor (Auto Bolt Rifle, Bolt pistol, Frag & Krak grenades)",
-                  "Intercessor Sergeant (Auto Bolt Rifle, Bolt pistol, Thunder hammer, Frag & Krak grenades)",
+                  "4x Intercessor (Auto Bolt Rifle [5 pts], Bolt pistol, Frag & Krak grenades)",
+                  "Intercessor Sergeant (Auto Bolt Rifle [5 pts], Bolt pistol, Thunder hammer [16 pts], Frag & Krak grenades)",
                   "Unit Upgrades (Auxiliary Grenade Launcher [1 pts], Veteran Intercessors [-1 CP])"
                 ],
                 '_weapons': [
@@ -206,7 +206,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Redemptor Dreadnought"}),
                 ],
                 '_modelList': [
-                  "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
+                  "Redemptor Dreadnought (2x Fragstorm Grenade Launchers [8 pts], Heavy flamer [14 pts], Heavy Onslaught Gatling Cannon [30 pts], Redemptor Fist)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
@@ -227,7 +227,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
                 ],
                 '_modelList': [
-                  "Assault Squad (5x Bolt pistol/Chainsword, 5x Frag & Krak grenades, 4x Bolt pistol, 4x Chainsword, Jump Pack)"
+                  "Assault Squad (5x Bolt pistol/Chainsword, 5x Frag & Krak grenades, 4x Bolt pistol, 4x Chainsword, Jump Pack [15 pts / 1 PL])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -243,7 +243,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
                 ],
                 '_modelList': [
-                  "Assault Squad (5x Bolt pistol/Chainsword, 5x Frag & Krak grenades, 4x Bolt pistol, 4x Chainsword, Jump Pack)"
+                  "Assault Squad (5x Bolt pistol/Chainsword, 5x Frag & Krak grenades, 4x Bolt pistol, 4x Chainsword, Jump Pack [15 pts / 1 PL])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -259,8 +259,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Suppressor Sergeant"}),
                 ],
                 '_modelList': [
-                  "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)",
-                  "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)"
+                  "2x Suppressor (Accelerator autocannon [10 pts], Bolt pistol, Frag & Krak grenades, Grav-chute [2 pts])",
+                  "Suppressor Sergeant (Accelerator autocannon [10 pts], Bolt pistol, Frag & Krak grenades, Grav-chute [2 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Accelerator autocannon"}),
@@ -276,8 +276,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
                 ],
                 '_modelList': [
-                  "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)",
-                  "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)"
+                  "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle [3 pts], Frag & Krak grenades, Camo cloak [3 pts])",
+                  "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle [3 pts], Frag & Krak grenades, Camo cloak [3 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -295,7 +295,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Predator"}),
                 ],
                 '_modelList': [
-                  "Predator (Two Heavy Bolters, Storm bolter, Twin lascannon)"
+                  "Predator (Two Heavy Bolters [20 pts], Storm bolter [2 pts], Twin lascannon [40 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy bolter"}),
@@ -314,7 +314,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Repulsor Executioner"}),
                 ],
                 '_modelList': [
-                  "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Onslaught Gatling Cannon, Macro Plasma Incinerator, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber, Auto Launchers)"
+                  "Repulsor Executioner (2x Fragstorm Grenade Launcher [8 pts], Heavy Onslaught Gatling Cannon [30 pts], Macro Plasma Incinerator [31 pts], 2x Storm bolter [4 pts], Twin Heavy Bolter [17 pts], Twin Icarus Ironhail Heavy Stubber [10 pts], Auto Launchers)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
@@ -337,7 +337,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Drop Pod"}),
                 ],
                 '_modelList': [
-                  "Drop Pod (Storm bolter)"
+                  "Drop Pod (Storm bolter [2 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -349,7 +349,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Impulsor"}),
                 ],
                 '_modelList': [
-                  "Impulsor (Ironhail Heavy Stubber, 2x Storm Bolters, Shield Dome)"
+                  "Impulsor (Ironhail Heavy Stubber [6 pts], 2x Storm Bolters [4 pts], Shield Dome [18 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),

--- a/spec/BlackTemplar2000Spec.ts
+++ b/spec/BlackTemplar2000Spec.ts
@@ -392,7 +392,17 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Bolter Discipline", jasmine.any(String)],
+              ["Angels of Death", jasmine.any(String)],
+              ["Shock Assault", jasmine.any(String)],
+              ["Righteous Zeal", jasmine.any(String)],
+              ["Explodes (6\"/D6)", jasmine.any(String)],
+              ["Explodes (6\"/D3)", jasmine.any(String)],
+              ["Smoke Launchers", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/BlackTemplar2000Spec.ts
+++ b/spec/BlackTemplar2000Spec.ts
@@ -146,7 +146,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Scout Sergeant"}),
                 ],
                 '_modelList': [
-                  "Scout Squad (2x Bolt pistol, 2x Boltgun, 2x Frag & Krak grenades)"
+                  "Scout Squad (5x Bolt pistol, 5x Boltgun, 5x Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -227,7 +227,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
                 ],
                 '_modelList': [
-                  "Assault Squad (2x Bolt pistol/Chainsword, 2x Frag & Krak grenades, Bolt pistol, Chainsword, Jump Pack)"
+                  "Assault Squad (5x Bolt pistol/Chainsword, 5x Frag & Krak grenades, 4x Bolt pistol, 4x Chainsword, Jump Pack)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -243,7 +243,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
                 ],
                 '_modelList': [
-                  "Assault Squad (2x Bolt pistol/Chainsword, 2x Frag & Krak grenades, Bolt pistol, Chainsword, Jump Pack)"
+                  "Assault Squad (5x Bolt pistol/Chainsword, 5x Frag & Krak grenades, 4x Bolt pistol, 4x Chainsword, Jump Pack)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),

--- a/spec/BlackTemplar2000Spec.ts
+++ b/spec/BlackTemplar2000Spec.ts
@@ -11,7 +11,11 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 104, _points: 1994, _commandPoints: 14}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - **Chapter Selection**: Imperial Fists Successor, Black Templars",
+              "No Force Org Slot - Battle-forged CP [3 CP]",
+              "No Force Org Slot - Detachment CP [12 CP]",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Captain in Phobos Armour",
@@ -356,53 +360,18 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Impulsor Wound Track 2"}),
                   jasmine.objectContaining({'_name': "Impulsor Wound Track 3"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "**Chapter Selection**",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Battle-forged CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 3}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 12}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
             '_rules': new Map([
               ["Bolter Discipline", jasmine.any(String)],
               ["Angels of Death", jasmine.any(String)],
               ["Shock Assault", jasmine.any(String)],
-              ["Righteous Zeal", jasmine.any(String)],
               ["Explodes (6\"/D6)", jasmine.any(String)],
               ["Explodes (6\"/D3)", jasmine.any(String)],
               ["Smoke Launchers", jasmine.any(String)],
             ]),
-            '_factionRules': new Map(),
+            '_factionRules': new Map([
+              ["Righteous Zeal", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/BloodAngelstestSpec.ts
+++ b/spec/BloodAngelstestSpec.ts
@@ -106,7 +106,18 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Frag grenades"}),
                   jasmine.objectContaining({'_name': "Krak grenades"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Bolter Discipline", jasmine.any(String)],
+              ["Angels of Death", jasmine.any(String)],
+              ["Shock Assault", jasmine.any(String)],
+              ["Savage Echoes", jasmine.any(String)],
+              ["Death from Above", jasmine.any(String)],
+              ["Combat Squads", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
+              ["The Red Thirst", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/BloodAngelstestSpec.ts
+++ b/spec/BloodAngelstestSpec.ts
@@ -26,7 +26,7 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "Lieutenant in Phobos Armour (Bolt pistol, Master-crafted occulus bolt carbine, Paired Combat Blades, Frag & Krak grenades)",
-                  "Primaris Lieutenant (Bolt pistol, Neo-volkite pistol, Master-crafted power sword, Frag & Krak grenades, Storm shield)"
+                  "Primaris Lieutenant (Bolt pistol, Neo-volkite pistol [15 pts], Master-crafted power sword, Frag & Krak grenades, Storm shield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),

--- a/spec/ChaosSMTestSpec.ts
+++ b/spec/ChaosSMTestSpec.ts
@@ -11,7 +11,11 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 130, _points: 1973, _commandPoints: 13}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Legion: Renegade Chapters",
+              "No Force Org Slot - Battle-forged CP [3 CP]",
+              "No Force Org Slot - Detachment CP [5 CP]",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Daemon Prince",
@@ -228,42 +232,6 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Heldrake2"}),
                   jasmine.objectContaining({'_name': "Heldrake3"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "Battle-forged CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 3}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 5}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Legion",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  "Unit Upgrades (Renegade Chapters)"
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
             '_rules': new Map([
               ["Despoilers of the Galaxy (Renegade Chapters)", jasmine.any(String)],
@@ -271,10 +239,15 @@ describe("Create40kRoster", function() {
               ["Hateful Assault", jasmine.any(String)],
               ["Hateful Volleys", jasmine.any(String)],
             ]),
-            '_factionRules': new Map(),
+            '_factionRules': new Map([
+              ["Dark Raiders", jasmine.any(String)],
+            ]),
           }),
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Chaos Allegiance: Chaos Undivided",
+              "No Force Org Slot - Detachment CP [5 CP]",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Fateskimmer",
@@ -407,30 +380,6 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Lashes of Torment"}),
                   jasmine.objectContaining({'_name': "Lashing tongues"}),
                   jasmine.objectContaining({'_name': "Piercing claws"}),
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Chaos Allegiance",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 5}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
                 ]}),
             ],
             '_rules': new Map([

--- a/spec/ChaosSMTestSpec.ts
+++ b/spec/ChaosSMTestSpec.ts
@@ -264,7 +264,14 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Despoilers of the Galaxy (Renegade Chapters)", jasmine.any(String)],
+              ["Daemonic Ritual", jasmine.any(String)],
+              ["Hateful Assault", jasmine.any(String)],
+              ["Hateful Volleys", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [],
@@ -425,7 +432,11 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Daemonic Ritual", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/ChaosSMTestSpec.ts
+++ b/spec/ChaosSMTestSpec.ts
@@ -24,7 +24,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Daemon Prince"}),
                 ],
                 '_modelList': [
-                  "Daemon Prince (Hellforged sword, Malefic talon)"
+                  "Daemon Prince (Hellforged sword [10 pts], Malefic talon)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Hellforged sword"}),
@@ -37,7 +37,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Lord Discordant on Helstalker"}),
                 ],
                 '_modelList': [
-                  "Lord Discordant on Helstalker (Autocannon, Bolt pistol, Bladed limbs and tail, Impaler chainglaive, Mechatendrils, Techno-virus injector, Frag & Krak grenades, 4. Hatred Incarnate, Intoxicating Elixir, Mark of Slaanesh, Warlord)"
+                  "Lord Discordant on Helstalker (Autocannon [10 pts], Bolt pistol, Bladed limbs and tail, Impaler chainglaive, Mechatendrils, Techno-virus injector, Frag & Krak grenades, 4. Hatred Incarnate, Intoxicating Elixir, Mark of Slaanesh, Warlord)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Autocannon"}),
@@ -62,7 +62,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Sorcerer"}),
                 ],
                 '_modelList': [
-                  "Sorcerer (Bolt pistol, Force sword, Frag & Krak grenades, No Chaos Mark, Smite)"
+                  "Sorcerer (Bolt pistol, Force sword [8 pts], Frag & Krak grenades, No Chaos Mark, Smite)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -135,8 +135,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Chaos Terminator Champion"}),
                 ],
                 '_modelList': [
-                  "Chaos Terminator Champion (Combi-bolter, Chainaxe)",
-                  "4x Terminator (Combi-bolter, Chainaxe)",
+                  "Chaos Terminator Champion (Combi-bolter [2 pts], Chainaxe [1 pts])",
+                  "4x Terminator (Combi-bolter [2 pts], Chainaxe [1 pts])",
                   "Unit Upgrades (Icon of Vengeance [5 pts], No Chaos Mark)"
                 ],
                 '_weapons': [
@@ -220,7 +220,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Heldrake"}),
                 ],
                 '_modelList': [
-                  "Heldrake (Hades Autocannon, Heldrake claws, No Chaos Mark)"
+                  "Heldrake (Hades Autocannon [20 pts], Heldrake claws, No Chaos Mark)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Hades autocannon"}),

--- a/spec/DeathGuardand1000SonsSpec.ts
+++ b/spec/DeathGuardand1000SonsSpec.ts
@@ -11,7 +11,12 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 129, _points: 2044, _commandPoints: 7}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Detachment CP [5 CP]",
+              "No Force Org Slot - Cults of the Legion: *No Cult*",
+              "No Force Org Slot - Battle-forged CP [3 CP]",
+              "No Force Org Slot - Detachment CP",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Ahriman",
@@ -342,54 +347,6 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Chaos Xiphon Interceptor1"}),
                   jasmine.objectContaining({'_name': "Chaos Xiphon Interceptor2"}),
                   jasmine.objectContaining({'_name': "Chaos Xiphon Interceptor3"}),
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Battle-forged CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 3}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Cults of the Legion",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 5}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
                 ]}),
             ],
             '_rules': new Map([

--- a/spec/DeathGuardand1000SonsSpec.ts
+++ b/spec/DeathGuardand1000SonsSpec.ts
@@ -391,7 +391,19 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Plague Weapon", jasmine.any(String)],
+              ["Inexorable Advance", jasmine.any(String)],
+              ["Plague Host", jasmine.any(String)],
+              ["Bolter Discipline", jasmine.any(String)],
+              ["Daemonic Ritual", jasmine.any(String)],
+              ["Hateful Assault", jasmine.any(String)],
+              ["Brotherhood of Sorcerors", jasmine.any(String)],
+              ["Malicious Volleys", jasmine.any(String)],
+              ["Disciples of Tzeentch", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/DeathGuardand1000SonsSpec.ts
+++ b/spec/DeathGuardand1000SonsSpec.ts
@@ -48,7 +48,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Lord of Contagion"}),
                 ],
                 '_modelList': [
-                  "Lord of Contagion (Manreaper)"
+                  "Lord of Contagion (Manreaper [17 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Manreaper"}),
@@ -60,7 +60,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Sorcerer"}),
                 ],
                 '_modelList': [
-                  "Sorcerer (Coruscator, Inferno Bolt Pistol, Force sword, Frag & Krak grenades, 2. Undying Form, Gift of Chaos, Magister [-1 CP], Smite)"
+                  "Sorcerer (Coruscator, Inferno Bolt Pistol, Force sword [8 pts], Frag & Krak grenades, 2. Undying Form, Gift of Chaos, Magister [-1 CP], Smite)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Coruscator"}),
@@ -87,7 +87,7 @@ describe("Create40kRoster", function() {
                 '_modelList': [
                   "9x Chaos Cultist w/ Autogun (Autogun)",
                   "Chaos Cultist w/ autopistol and brutal assault weapon (Autopistol, Brutal assault weapon)",
-                  "Chaos Cultist w/ special weapon (Heavy stubber)",
+                  "Chaos Cultist w/ special weapon (Heavy stubber [2 pts])",
                   "Cultist Champion (Brutal assault weapon and Autopistol)"
                 ],
                 '_weapons': [
@@ -105,9 +105,9 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "Plague Champion (Boltgun, Plague knife, Blight Grenades, Krak grenades)",
-                  "Plague Marine w/ Special Weapon (Plasma gun, Plague knife, Blight Grenades, Krak grenades)",
+                  "Plague Marine w/ Special Weapon (Plasma gun [11 pts], Plague knife, Blight Grenades, Krak grenades)",
                   "4x Plague Marine w/ boltgun (Boltgun, Plague knife, Blight Grenades, Krak Grenades)",
-                  "Plague Marine w/ melee weapons (Flail of Corruption, Plague knife, Blight Grenades, Krak grenades)"
+                  "Plague Marine w/ melee weapons (Flail of Corruption [10 pts], Plague knife, Blight Grenades, Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Boltgun"}),
@@ -138,10 +138,10 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Rubric Marine"}),
                 ],
                 '_modelList': [
-                  "Aspiring Sorcerer (Plasma pistol, Force sword, Glamour of Tzeentch, Smite)",
+                  "Aspiring Sorcerer (Plasma pistol [5 pts], Force sword [8 pts], Glamour of Tzeentch, Smite)",
                   "8x Rubric Marine w/ Inferno Boltgun (Inferno boltgun)",
-                  "Rubric Marine w/ Soulreaper cannon (Soulreaper cannon)",
-                  "Rubric Marine w/ Warpflamer (Warpflamer)",
+                  "Rubric Marine w/ Soulreaper cannon (Soulreaper cannon [10 pts])",
+                  "Rubric Marine w/ Warpflamer (Warpflamer [8 pts])",
                   "Unit Upgrades (Icon of Flame [5 pts])"
                 ],
                 '_weapons': [
@@ -168,7 +168,7 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "Plague Champion (Bolt pistol, Boltgun, 2x Plague knife, 2x Blight Grenades, 2x Krak grenades)",
-                  "Plague Marine (Boltgun, Meltagun, 2x Plague knife, 2x Blight Grenades, 2x Krak grenades)"
+                  "Plague Marine (Boltgun, Meltagun [14 pts], 2x Plague knife, 2x Blight Grenades, 2x Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -217,7 +217,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Helbrute"}),
                 ],
                 '_modelList': [
-                  "Helbrute (Multi-melta, Helbrute fist)"
+                  "Helbrute (Multi-melta [22 pts], Helbrute fist [20 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Multi-melta"}),
@@ -230,7 +230,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Tallyman"}),
                 ],
                 '_modelList': [
-                  "Tallyman (Plasma pistol, Blight Grenades, Krak grenades)"
+                  "Tallyman (Plasma pistol [5 pts], Blight Grenades, Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Plasma pistol, Standard"}),
@@ -245,7 +245,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Tzaangor Shaman"}),
                 ],
                 '_modelList': [
-                  "Tzaangor Shaman (Blades on Disc of Tzeentch, Force stave, Smite)"
+                  "Tzaangor Shaman (Blades on Disc of Tzeentch, Force stave [8 pts], Smite)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Blades on Disc of Tzeentch"}),
@@ -264,7 +264,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Foetid Bloat-drone"}),
                 ],
                 '_modelList': [
-                  "Foetid Bloat-drone (2x Plaguespitters, Plague probe)"
+                  "Foetid Bloat-drone (2x Plaguespitters [34 pts], Plague probe [5 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Plaguespitter"}),
@@ -283,7 +283,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Greater Blight Drone"}),
                 ],
                 '_modelList': [
-                  "Greater Blight Drone (Bile maw, Blightreaper cannon, Plague probe)"
+                  "Greater Blight Drone (Bile maw [18 pts], Blightreaper cannon [18 pts], Plague probe [25 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bile maw"}),
@@ -304,8 +304,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Enlightened"}),
                 ],
                 '_modelList': [
-                  "Aviarch (Divining spears)",
-                  "2x Enlightened (Blades on Disc of Tzeentch, Divining spears)"
+                  "Aviarch (Divining spears [3 pts])",
+                  "2x Enlightened (Blades on Disc of Tzeentch, Divining spears [3 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Blades on Disc of Tzeentch"}),
@@ -318,7 +318,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Plagueburst Crawler"}),
                 ],
                 '_modelList': [
-                  "Plagueburst Crawler (2x Entropy cannon, Heavy slugger, Plagueburst Mortar)"
+                  "Plagueburst Crawler (2x Entropy cannon [30 pts], Heavy slugger [6 pts], Plagueburst Mortar)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Entropy cannon"}),
@@ -337,7 +337,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Chaos Xiphon Interceptor"}),
                 ],
                 '_modelList': [
-                  "Chaos Xiphon Interceptor (Soulstalker missiles, 2x Twin lascannon)"
+                  "Chaos Xiphon Interceptor (Soulstalker missiles [50 pts], 2x Twin lascannon [80 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Soulstalker missiles"}),

--- a/spec/DrukariTestSpec.ts
+++ b/spec/DrukariTestSpec.ts
@@ -13,7 +13,7 @@ describe("Create40kRoster", function() {
           jasmine.objectContaining({
             '_configurations': [
               "Detachment Type: Mixed Detachment",
-              "Detachment CP",
+              "Detachment CP [5 CP]",
             ],
             '_units': [
               jasmine.objectContaining({
@@ -248,8 +248,8 @@ describe("Create40kRoster", function() {
           jasmine.objectContaining({
             '_configurations': [
               "Masque Form: The Silent Shroud: Dance of Nightmares Made Flesh",
-              "Battle-forged CP",
-              "Detachment CP",
+              "Battle-forged CP [3 CP]",
+              "Detachment CP [5 CP]",
             ],
             '_units': [
               jasmine.objectContaining({

--- a/spec/DrukariTestSpec.ts
+++ b/spec/DrukariTestSpec.ts
@@ -236,7 +236,14 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Twin splinter rifle"}),
                   jasmine.objectContaining({'_name': "Bladevanes"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Poisoned Weapon", jasmine.any(String)],
+              ["Power from Pain", jasmine.any(String)],
+              ["Vanguard of the Dark City", jasmine.any(String)],
+              ["Combat Drugs", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [
@@ -394,7 +401,13 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Shuriken Cannon"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Strength from Death", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
+              ["The Silent Shroud: Dance of Nightmares Made Flesh", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/DrukariTestSpec.ts
+++ b/spec/DrukariTestSpec.ts
@@ -23,7 +23,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Archon"}),
                 ],
                 '_modelList': [
-                  "Archon (Splinter pistol, Huskblade, Shadowfield)"
+                  "Archon (Splinter pistol, Huskblade [6 pts], Shadowfield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Splinter pistol"}),
@@ -36,7 +36,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Haemonculus"}),
                 ],
                 '_modelList': [
-                  "Haemonculus (Splinter pistol, Agoniser)"
+                  "Haemonculus (Splinter pistol, Agoniser [4 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Splinter pistol"}),
@@ -93,7 +93,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Grotesque"}),
                 ],
                 '_modelList': [
-                  "3x Grotesque with Monstrous Cleaver (Flesh gauntlet, Monstrous cleaver)"
+                  "3x Grotesque with Monstrous Cleaver (Flesh gauntlet [3 pts], Monstrous cleaver)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Flesh Gauntlet"}),
@@ -152,7 +152,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Ravager"}),
                 ],
                 '_modelList': [
-                  "Ravager (3x Dark Lance, Bladevanes, Night Shield)"
+                  "Ravager (3x Dark Lance [45 pts], Bladevanes, Night Shield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Dark Lance"}),
@@ -210,7 +210,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Raider"}),
                 ],
                 '_modelList': [
-                  "Raider (Dark Lance, Bladevanes, Night Shield)"
+                  "Raider (Dark Lance [15 pts], Bladevanes, Night Shield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Dark Lance"}),
@@ -229,7 +229,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Venom"}),
                 ],
                 '_modelList': [
-                  "Venom (Splinter Cannon, Twin splinter rifle, Bladevanes, Flickerfield, Night Shield)"
+                  "Venom (Splinter Cannon [10 pts], Twin splinter rifle, Bladevanes, Flickerfield, Night Shield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Splinter Cannon"}),
@@ -370,7 +370,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Skyweaver"}),
                 ],
                 '_modelList': [
-                  "2x Skyweaver (Shuriken Cannon, Star Bolas)"
+                  "2x Skyweaver (Shuriken Cannon [10 pts], Star Bolas)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Shuriken Cannon"}),
@@ -383,7 +383,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Voidweaver"}),
                 ],
                 '_modelList': [
-                  "Voidweaver (Haywire Cannon, 2x Shuriken Cannon)"
+                  "Voidweaver (Haywire Cannon [15 pts], 2x Shuriken Cannon [20 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Haywire Cannon"}),
@@ -396,7 +396,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Starweaver"}),
                 ],
                 '_modelList': [
-                  "Starweaver (2x Shuriken Cannon)"
+                  "Starweaver (2x Shuriken Cannon [20 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Shuriken Cannon"}),

--- a/spec/GreyKnightsSpec.ts
+++ b/spec/GreyKnightsSpec.ts
@@ -25,7 +25,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Brother Captain"}),
                 ],
                 '_modelList': [
-                  "Brother-Captain (Storm Bolter, Nemesis Force Halberd, Frag & Krak grenades, Psyk-out Grenade, Domina Liber Demonica, Iron Halo, Warlord)"
+                  "Brother-Captain (Storm Bolter [2 pts], Nemesis Force Halberd [1 pts], Frag & Krak grenades, Psyk-out Grenade, Domina Liber Demonica, Iron Halo, Warlord)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -47,7 +47,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Grey Knight Chaplain"}),
                 ],
                 '_modelList': [
-                  "Chaplain (Storm bolter, Crozius Arcanum, Frag & Krak grenades, Psyk-out Grenade, Sanctuary)"
+                  "Chaplain (Storm bolter [2 pts], Crozius Arcanum, Frag & Krak grenades, Psyk-out Grenade, Sanctuary)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -70,7 +70,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Grand Master"}),
                 ],
                 '_modelList': [
-                  "Grand Master (Storm Bolter, Nemesis Force Halberd, Frag & Krak grenades, Psyk-out Grenade, Inner Fire, Iron Halo)"
+                  "Grand Master (Storm Bolter [2 pts], Nemesis Force Halberd [1 pts], Frag & Krak grenades, Psyk-out Grenade, Inner Fire, Iron Halo)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -94,8 +94,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Grey Knight Justicar"}),
                 ],
                 '_modelList': [
-                  "4x Grey Knight (Sword) (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)",
-                  "Grey Knight Justicar (Storm bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)"
+                  "4x Grey Knight (Sword) (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)",
+                  "Grey Knight Justicar (Storm bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -118,8 +118,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Grey Knight Justicar"}),
                 ],
                 '_modelList': [
-                  "4x Grey Knight (Sword) (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)",
-                  "Grey Knight Justicar (Storm bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)"
+                  "4x Grey Knight (Sword) (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)",
+                  "Grey Knight Justicar (Storm bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -142,8 +142,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Grey Knight Terminator Justicar"}),
                 ],
                 '_modelList': [
-                  "Grey Knight Terminator Justicar (Storm bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)",
-                  "4x Terminator (Sword) (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)"
+                  "Grey Knight Terminator Justicar (Storm bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)",
+                  "4x Terminator (Sword) (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -167,8 +167,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Paragon"}),
                 ],
                 '_modelList': [
-                  "2x Paladin (Sword) (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)",
-                  "Paragon (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)"
+                  "2x Paladin (Sword) (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)",
+                  "Paragon (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -192,8 +192,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Paragon"}),
                 ],
                 '_modelList': [
-                  "2x Paladin (Sword) (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)",
-                  "Paragon (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)"
+                  "2x Paladin (Sword) (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)",
+                  "Paragon (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -217,8 +217,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Purifier"}),
                 ],
                 '_modelList': [
-                  "Knight of the Flame (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)",
-                  "4x Purifier (Sword) (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)"
+                  "Knight of the Flame (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)",
+                  "4x Purifier (Sword) (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -242,8 +242,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Purgator Justicar"}),
                 ],
                 '_modelList': [
-                  "4x Purgator (Sword) (Storm Bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)",
-                  "Purgator Justicar (Storm bolter, Nemesis Force Sword, Frag & Krak grenades, Psyk-out Grenade)"
+                  "4x Purgator (Sword) (Storm Bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)",
+                  "Purgator Justicar (Storm bolter [2 pts], Nemesis Force Sword [1 pts], Frag & Krak grenades, Psyk-out Grenade)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),

--- a/spec/GreyKnightsSpec.ts
+++ b/spec/GreyKnightsSpec.ts
@@ -12,8 +12,8 @@ describe("Create40kRoster", function() {
         '_forces': [
           jasmine.objectContaining({
             '_configurations': [
-              "Battle-forged CP",
-              "Detachment CP",
+              "Battle-forged CP [3 CP]",
+              "Detachment CP [5 CP]",
               "Detachment Bonuses: Show Bonuses",
               "Stratagems - Armoury of Titan",
             ],

--- a/spec/GreyKnightsSpec.ts
+++ b/spec/GreyKnightsSpec.ts
@@ -258,7 +258,29 @@ describe("Create40kRoster", function() {
                 '_psykers': [
                   jasmine.objectContaining({'_name': "Psyker (Sanctic 1 Squad)"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Psychic Locus", jasmine.any(String)],
+              ["And They Shall Know No Fear", jasmine.any(String)],
+              ["Daemon Hunters", jasmine.any(String)],
+              ["Teleport Strike", jasmine.any(String)],
+              ["Rites of Banishment", jasmine.any(String)],
+              ["Bolter Discipline", jasmine.any(String)],
+              ["Shock Assault", jasmine.any(String)],
+              ["Masters of the Warp", jasmine.any(String)],
+              ["Iron Halo", jasmine.any(String)],
+              ["Domina Liber Demonica", jasmine.any(String)],
+              ["Rosarius", jasmine.any(String)],
+              ["Spiritual Leaders", jasmine.any(String)],
+              ["Combat Squads", jasmine.any(String)],
+              ["Crux Terminatus", jasmine.any(String)],
+              ["Rites of Battle", jasmine.any(String)],
+              ["Purifying Flame", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
+              ["Brotherhood of Psykers", jasmine.any(String)],
+              ["Knights of Titan", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/GuardSpec.ts
+++ b/spec/GuardSpec.ts
@@ -331,7 +331,12 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Defenders of Humanity", jasmine.any(String)],
+              ["Avalanche of Muscle", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/GuardSpec.ts
+++ b/spec/GuardSpec.ts
@@ -37,7 +37,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Knight Commander Pask"}),
                 ],
                 '_modelList': [
-                  "Knight Commander Pask (Battle Cannon, Heavy Bolter, Stat Damage (Pask))"
+                  "Knight Commander Pask (Battle Cannon [22 pts], Heavy Bolter [8 pts], Stat Damage (Pask))"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Battle Cannon"}),
@@ -148,9 +148,9 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Scion (Hot-shot Lasgun, Frag & Krak grenades)",
-                  "Scion w/ Special Weapon (Grenade Launcher, Frag & Krak grenades)",
-                  "Scion w/ Vox-caster (Hot-Shot Lasgun, Hot-shot Laspistol, Vox-caster)",
-                  "Tempestor (Hot-shot Laspistol, Power fist, Frag & Krak grenades)"
+                  "Scion w/ Special Weapon (Grenade Launcher [3 pts], Frag & Krak grenades)",
+                  "Scion w/ Vox-caster (Hot-Shot Lasgun, Hot-shot Laspistol, Vox-caster [5 pts])",
+                  "Tempestor (Hot-shot Laspistol, Power fist [8 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Grenade Launcher (Frag)"}),
@@ -169,8 +169,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Bullgryn Bone 'ead"}),
                 ],
                 '_modelList': [
-                  "2x Bullgryn (Grenadier Gauntlet, Frag Bombs, Slabshield)",
-                  "Bullgryn Bone 'ead (Grenadier Gauntlet, Frag Bombs, Slabshield)"
+                  "2x Bullgryn (Grenadier Gauntlet [5 pts], Frag Bombs, Slabshield)",
+                  "Bullgryn Bone 'ead (Grenadier Gauntlet [5 pts], Frag Bombs, Slabshield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Grenadier Gauntlet"}),
@@ -204,9 +204,9 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "3x Guardsman (Lasgun, Frag grenade)",
-                  "Guardsman W/ Special Weapon (Grenade Launcher, Frag grenade)",
-                  "Guardsman W/ Special Weapon (Meltagun, Frag grenade)",
-                  "Guardsman W/ Special Weapon (Sniper rifle, Frag grenade)"
+                  "Guardsman W/ Special Weapon (Grenade Launcher [3 pts], Frag grenade)",
+                  "Guardsman W/ Special Weapon (Meltagun [10 pts], Frag grenade)",
+                  "Guardsman W/ Special Weapon (Sniper rifle [2 pts], Frag grenade)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Grenade Launcher (Frag)"}),
@@ -223,9 +223,9 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Hellhound"}),
                 ],
                 '_modelList': [
-                  "Bane Wolf (Turret-mounted Chem Cannon, Heavy Bolter, Stat Damage (HS))",
-                  "Devil Dog (Heavy Bolter, Turret-mounted Melta Cannon, Stat Damage (HS))",
-                  "Hellhound (Heavy Bolter, Turret-mounted Inferno Cannon, Stat Damage (HS))"
+                  "Bane Wolf (Turret-mounted Chem Cannon [7 pts], Heavy Bolter [8 pts], Stat Damage (HS))",
+                  "Devil Dog (Heavy Bolter [8 pts], Turret-mounted Melta Cannon [20 pts], Stat Damage (HS))",
+                  "Hellhound (Heavy Bolter [8 pts], Turret-mounted Inferno Cannon [20 pts], Stat Damage (HS))"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Chem Cannon"}),
@@ -251,7 +251,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Scout Sentinel"}),
                 ],
                 '_modelList': [
-                  "Scout Sentinel (Multi-laser)"
+                  "Scout Sentinel (Multi-laser [5 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Multi-laser"}),
@@ -263,7 +263,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Tauros"}),
                 ],
                 '_modelList': [
-                  "Tauros (Twin Multi-Laser)"
+                  "Tauros (Twin Multi-Laser [18 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Twin Multi-Laser"}),
@@ -275,7 +275,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Hydra"}),
                 ],
                 '_modelList': [
-                  "Hydra (Heavy Bolter, Hydra Quad Autocannon, Stat Damage (HS))"
+                  "Hydra (Heavy Bolter [8 pts], Hydra Quad Autocannon, Stat Damage (HS))"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy bolter"}),
@@ -310,7 +310,7 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "Unit Upgrades (Stat Damage (HS))",
-                  "Wyvern (Heavy Bolter, Wyven Quad Stormshard Mortar)"
+                  "Wyvern (Heavy Bolter [8 pts], Wyven Quad Stormshard Mortar)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy bolter"}),

--- a/spec/GuardSpec.ts
+++ b/spec/GuardSpec.ts
@@ -11,7 +11,9 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 101, _points: 1625, _commandPoints: 0}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Regimental Doctrine: Astra Millitarum",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Commissar Yarrick",
@@ -318,18 +320,6 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Stat Damage (HS) 1"}),
                   jasmine.objectContaining({'_name': "Stat Damage (HS) 2"}),
                   jasmine.objectContaining({'_name': "Stat Damage (HS) 3"}),
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Regimental Doctrine",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
                 ]}),
             ],
             '_rules': new Map([

--- a/spec/KnightsSpec.ts
+++ b/spec/KnightsSpec.ts
@@ -11,7 +11,9 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 90, _points: 1904, _commandPoints: 0}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Household Choice: Questor Imperialis, House Griffith, Household Tradition: Glory of the Charge",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Armiger Helverins",
@@ -131,23 +133,13 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Knight Gallant 2"}),
                   jasmine.objectContaining({'_name': "Knight Gallant 3"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "Household Choice",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  "Unit Upgrades (House Griffith, Questor Imperialis)"
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
             '_rules': new Map([
               ["Knight Lance", jasmine.any(String)],
             ]),
-            '_factionRules': new Map(),
+            '_factionRules': new Map([
+              ["Glory of the Charge", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/KnightsSpec.ts
+++ b/spec/KnightsSpec.ts
@@ -143,7 +143,11 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Knight Lance", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/KnightsSpec.ts
+++ b/spec/KnightsSpec.ts
@@ -22,7 +22,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Armiger Helverin"}),
                 ],
                 '_modelList': [
-                  "Armiger Helverin (2x Armiger Autocannon, Meltagun)"
+                  "Armiger Helverin (2x Armiger Autocannon, Meltagun [14 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Armiger Autocannon"}),
@@ -43,7 +43,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Armiger Warglaive"}),
                 ],
                 '_modelList': [
-                  "Armiger Warglaive (Meltagun, Thermal Spear, Reaper Chain-Cleaver)"
+                  "Armiger Warglaive (Meltagun [14 pts], Thermal Spear, Reaper Chain-Cleaver)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Meltagun"}),
@@ -66,7 +66,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Knight Castellan"}),
                 ],
                 '_modelList': [
-                  "Knight Castellan (Plasma Decimator, 2x Shieldbreaker Missile, 2x Twin Meltagun, 2x Twin Siegebreaker Cannon, Volcano Lance, Titanic Feet, Character (Knight Lance), Heirloom: Armour of the Sainted Ion, Warlord, Warlord Trait: Fearsome Reputation)"
+                  "Knight Castellan (Plasma Decimator [40 pts], 2x Shieldbreaker Missile [24 pts], 2x Twin Meltagun, 2x Twin Siegebreaker Cannon [70 pts], Volcano Lance [60 pts], Titanic Feet, Character (Knight Lance), Heirloom: Armour of the Sainted Ion, Warlord, Warlord Trait: Fearsome Reputation)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Plasma Decimator (Standard)"}),
@@ -92,7 +92,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Knight Errant"}),
                 ],
                 '_modelList': [
-                  "Knight Errant (Meltagun, Stormspear Rocket Pod, Thermal Cannon, Thunderstrike gauntlet, Titanic Feet)"
+                  "Knight Errant (Meltagun [14 pts], Stormspear Rocket Pod [45 pts], Thermal Cannon [76 pts], Thunderstrike gauntlet [35 pts], Titanic Feet)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Meltagun"}),
@@ -116,7 +116,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Knight Gallant"}),
                 ],
                 '_modelList': [
-                  "Knight Gallant (Heavy Stubber, Stormspear Rocket Pod, Reaper Chainsword, Thunderstrike gauntlet, Titanic Feet)"
+                  "Knight Gallant (Heavy Stubber [2 pts], Stormspear Rocket Pod [45 pts], Reaper Chainsword [30 pts], Thunderstrike gauntlet [35 pts], Titanic Feet)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy stubber"}),

--- a/spec/Knights_AstraMilitarumSpec.ts
+++ b/spec/Knights_AstraMilitarumSpec.ts
@@ -13,7 +13,7 @@ describe("Create40kRoster", function() {
           jasmine.objectContaining({
             '_configurations': [
               "Household Choice: Questor Imperialis, House Griffith, Household Tradition: Glory of the Charge",
-              "Detachment CP",
+              "Detachment CP [3 CP]",
             ],
             '_units': [
               jasmine.objectContaining({
@@ -114,11 +114,13 @@ describe("Create40kRoster", function() {
             '_rules': new Map([
               ["Knight Lance", jasmine.any(String)],
             ]),
-            '_factionRules': new Map(),
+            '_factionRules': new Map([
+              ["Glory of the Charge", jasmine.any(String)],
+            ]),
           }),
           jasmine.objectContaining({
             '_configurations': [
-              "Detachment CP",
+              "Detachment CP [5 CP]",
               "Regimental Doctrine: Astra Millitarum",
             ],
             '_units': [
@@ -206,7 +208,7 @@ describe("Create40kRoster", function() {
           }),
           jasmine.objectContaining({
             '_configurations': [
-              "Detachment CP",
+              "Detachment CP [5 CP]",
               "Regimental Doctrine: Regiment: Catachan",
             ],
             '_units': [

--- a/spec/Knights_AstraMilitarumSpec.ts
+++ b/spec/Knights_AstraMilitarumSpec.ts
@@ -23,7 +23,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Armiger Helverin"}),
                 ],
                 '_modelList': [
-                  "Armiger Helverin (2x Armiger Autocannon, Meltagun)"
+                  "Armiger Helverin (2x Armiger Autocannon, Meltagun [14 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Armiger Autocannon"}),
@@ -44,7 +44,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Armiger Warglaive"}),
                 ],
                 '_modelList': [
-                  "Armiger Warglaive (Meltagun, Thermal Spear, Reaper Chain-Cleaver)"
+                  "Armiger Warglaive (Meltagun [14 pts], Thermal Spear, Reaper Chain-Cleaver)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Meltagun"}),
@@ -67,7 +67,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Knight Castellan"}),
                 ],
                 '_modelList': [
-                  "Knight Castellan (Plasma Decimator, 2x Shieldbreaker Missile, 2x Twin Meltagun, 2x Twin Siegebreaker Cannon, Volcano Lance, Titanic Feet, Character (Knight Lance), Heirloom: Armour of the Sainted Ion, Warlord, Warlord Trait: Fearsome Reputation)"
+                  "Knight Castellan (Plasma Decimator [40 pts], 2x Shieldbreaker Missile [24 pts], 2x Twin Meltagun, 2x Twin Siegebreaker Cannon [70 pts], Volcano Lance [60 pts], Titanic Feet, Character (Knight Lance), Heirloom: Armour of the Sainted Ion, Warlord, Warlord Trait: Fearsome Reputation)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Plasma Decimator (Standard)"}),
@@ -93,7 +93,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Knight Crusader"}),
                 ],
                 '_modelList': [
-                  "Knight Crusader (Avenger Gatling Cannon, Heavy Flamer, Heavy Stubber, Thermal Cannon, Titanic Feet)"
+                  "Knight Crusader (Avenger Gatling Cannon [75 pts], Heavy Flamer [14 pts], Heavy Stubber [2 pts], Thermal Cannon [76 pts], Titanic Feet)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Avenger Gatling Cannon"}),
@@ -296,8 +296,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Bullgryn Bone 'ead"}),
                 ],
                 '_modelList': [
-                  "2x Bullgryn (Grenadier Gauntlet, Frag Bombs, Slabshield)",
-                  "Bullgryn Bone 'ead (Grenadier Gauntlet, Frag Bombs, Slabshield)"
+                  "2x Bullgryn (Grenadier Gauntlet [5 pts], Frag Bombs, Slabshield)",
+                  "Bullgryn Bone 'ead (Grenadier Gauntlet [5 pts], Frag Bombs, Slabshield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Grenadier Gauntlet"}),

--- a/spec/Knights_AstraMilitarumSpec.ts
+++ b/spec/Knights_AstraMilitarumSpec.ts
@@ -110,7 +110,11 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Knight Crusader 2"}),
                   jasmine.objectContaining({'_name': "Knight Crusader 3"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Knight Lance", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [
@@ -194,7 +198,11 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Laspistol"}),
                   jasmine.objectContaining({'_name': "Frag grenade"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Defenders of Humanity", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [
@@ -293,7 +301,13 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Grenadier Gauntlet"}),
                   jasmine.objectContaining({'_name': "Frag Bombs"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Avalanche of Muscle", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
+              ["Brutal Strength", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/MagnusSpec.ts
+++ b/spec/MagnusSpec.ts
@@ -12,8 +12,8 @@ describe("Create40kRoster", function() {
         '_forces': [
           jasmine.objectContaining({
             '_configurations': [
-              "Battle-forged CP",
-              "Detachment CP",
+              "Battle-forged CP [3 CP]",
+              "Detachment CP [5 CP]",
               "Cults of the Legion: Cult of Scheming",
             ],
             '_units': [

--- a/spec/MagnusSpec.ts
+++ b/spec/MagnusSpec.ts
@@ -166,7 +166,15 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Heldrake2"}),
                   jasmine.objectContaining({'_name': "Heldrake3"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Daemonic Ritual", jasmine.any(String)],
+              ["Brotherhood of Sorcerors", jasmine.any(String)],
+              ["Hateful Assault", jasmine.any(String)],
+              ["Malicious Volleys", jasmine.any(String)],
+              ["Disciples of Tzeentch", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [
@@ -197,7 +205,12 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Magnus the Red2"}),
                   jasmine.objectContaining({'_name': "Magnus the Red3"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Hateful Assault", jasmine.any(String)],
+              ["Malicious Volleys", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/MagnusSpec.ts
+++ b/spec/MagnusSpec.ts
@@ -45,7 +45,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Exalted Sorcerer"}),
                 ],
                 '_modelList': [
-                  "Exalted Sorcerer (Inferno Bolt Pistol, Force stave, Frag & Krak grenades, Smite)"
+                  "Exalted Sorcerer (Inferno Bolt Pistol, Force stave [8 pts], Frag & Krak grenades, Smite)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
@@ -82,7 +82,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Rubric Marine"}),
                 ],
                 '_modelList': [
-                  "Aspiring Sorcerer (Inferno Bolt Pistol, Force stave, Smite)",
+                  "Aspiring Sorcerer (Inferno Bolt Pistol, Force stave [8 pts], Smite)",
                   "4x Rubric Marine w/ Inferno Boltgun (Inferno boltgun)"
                 ],
                 '_weapons': [
@@ -118,7 +118,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Helbrute"}),
                 ],
                 '_modelList': [
-                  "Helbrute (Multi-melta, Helbrute fist)"
+                  "Helbrute (Multi-melta [22 pts], Helbrute fist [20 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Multi-melta"}),
@@ -132,8 +132,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Scarab Occult Terminator"}),
                 ],
                 '_modelList': [
-                  "Scarab Occult Sorcerer (Inferno Combi-bolter, Force stave, Smite)",
-                  "4x Terminator (Inferno Combi-bolter, Powersword)"
+                  "Scarab Occult Sorcerer (Inferno Combi-bolter [3 pts], Force stave [8 pts], Smite)",
+                  "4x Terminator (Inferno Combi-bolter [3 pts], Powersword [4 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Inferno Combi-bolter"}),
@@ -154,7 +154,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Heldrake"}),
                 ],
                 '_modelList': [
-                  "Heldrake (Hades Autocannon, Heldrake claws)"
+                  "Heldrake (Hades Autocannon [20 pts], Heldrake claws)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Hades autocannon"}),

--- a/spec/Magnus_9thSpec.ts
+++ b/spec/Magnus_9thSpec.ts
@@ -123,7 +123,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Helbrute"}),
                 ],
                 '_modelList': [
-                  "Helbrute (Multi-melta, Helbrute fist)"
+                  "Helbrute (Multi-melta [25 pts], Helbrute fist [20 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Multi-melta"}),
@@ -137,8 +137,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Scarab Occult Terminator"}),
                 ],
                 '_modelList': [
-                  "Scarab Occult Sorcerer (Inferno Combi-bolter, Force stave, Smite)",
-                  "4x Terminator (Inferno Combi-bolter, Power sword)"
+                  "Scarab Occult Sorcerer (Inferno Combi-bolter [3 pts], Force stave, Smite)",
+                  "4x Terminator (Inferno Combi-bolter [3 pts], Power sword [5 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Inferno Combi-bolter"}),
@@ -159,7 +159,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Heldrake"}),
                 ],
                 '_modelList': [
-                  "Heldrake (Hades autocannon, Heldrake claws)"
+                  "Heldrake (Hades autocannon [25 pts], Heldrake claws)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Hades autocannon"}),

--- a/spec/Magnus_9thSpec.ts
+++ b/spec/Magnus_9thSpec.ts
@@ -14,7 +14,8 @@ describe("Create40kRoster", function() {
             '_configurations': [
               "Battle Size: 3. Strike Force (101-200 Total PL / 1001-2000 Points)  [12 CP]",
               "Cults of the Legion: Cult of Scheming",
-              "Detachment CP",
+              "Gametype: Matched",
+              "Detachment CP [-3 CP]",
             ],
             '_units': [
               jasmine.objectContaining({
@@ -183,7 +184,7 @@ describe("Create40kRoster", function() {
           jasmine.objectContaining({
             '_configurations': [
               "Cults of the Legion: Cult of Prophecy",
-              "Detachment CP",
+              "Detachment CP [-3 CP]",
             ],
             '_units': [
               jasmine.objectContaining({

--- a/spec/Magnus_9thSpec.ts
+++ b/spec/Magnus_9thSpec.ts
@@ -170,7 +170,15 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Heldrake2"}),
                   jasmine.objectContaining({'_name': "Heldrake3"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Daemonic Ritual", jasmine.any(String)],
+              ["Brotherhood of Sorcerors", jasmine.any(String)],
+              ["Hateful Assault", jasmine.any(String)],
+              ["Malicious Volleys", jasmine.any(String)],
+              ["Disciples of Tzeentch", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [
@@ -202,7 +210,12 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Magnus the Red2"}),
                   jasmine.objectContaining({'_name': "Magnus the Red3"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Hateful Assault", jasmine.any(String)],
+              ["Malicious Volleys", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/NecronJune20212Spec.ts
+++ b/spec/NecronJune20212Spec.ts
@@ -93,7 +93,19 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Scouring Eye"}),
                   jasmine.objectContaining({'_name': "Scythed Limbs"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Dynastic Agents and Star Gods", jasmine.any(String)],
+              ["The Royal Court", jasmine.any(String)],
+              ["Command Protocols", jasmine.any(String)],
+              ["Living Metal", jasmine.any(String)],
+              ["Reanimation Protocols", jasmine.any(String)],
+              ["Objective Secured", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
+              ["Unyielding", jasmine.any(String)],
+              ["Healthy Paranoia", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/NecronTestSpec.ts
+++ b/spec/NecronTestSpec.ts
@@ -123,7 +123,13 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Living Metal", jasmine.any(String)],
+              ["Reanimation Protocols", jasmine.any(String)],
+              ["Their Number is Legion, Their Name is Death", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/NecronTestSpec.ts
+++ b/spec/NecronTestSpec.ts
@@ -22,7 +22,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Cryptek"}),
                 ],
                 '_modelList': [
-                  "Cryptek (Staff of Light)"
+                  "Cryptek (Staff of Light [10 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Staff of Light (Shooting)"}),
@@ -35,7 +35,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Overlord"}),
                 ],
                 '_modelList': [
-                  "Overlord (Staff of Light)"
+                  "Overlord (Staff of Light [10 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Staff of Light (Shooting)"}),
@@ -48,7 +48,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Immortal"}),
                 ],
                 '_modelList': [
-                  "5x Immortal (Gauss Blaster)"
+                  "5x Immortal (Gauss Blaster [35 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Gauss Blaster"}),

--- a/spec/NecronTestSpec.ts
+++ b/spec/NecronTestSpec.ts
@@ -11,7 +11,9 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 50, _points: 785, _commandPoints: 0}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Dynasty Choice",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Cryptek",
@@ -110,18 +112,6 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Doom Scythe Track 1"}),
                   jasmine.objectContaining({'_name': "Doom Scythe Track 2"}),
                   jasmine.objectContaining({'_name': "Doom Scythe Track 3"}),
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Dynasty Choice",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
                 ]}),
             ],
             '_rules': new Map([

--- a/spec/NotZippedSpec.ts
+++ b/spec/NotZippedSpec.ts
@@ -12,8 +12,8 @@ describe("Create40kRoster", function() {
         '_forces': [
           jasmine.objectContaining({
             '_configurations': [
-              "Battle-forged CP",
-              "Detachment CP",
+              "Battle-forged CP [3 CP]",
+              "Detachment CP [5 CP]",
               "Cults of the Legion: Cult of Scheming",
             ],
             '_units': [

--- a/spec/NotZippedSpec.ts
+++ b/spec/NotZippedSpec.ts
@@ -166,7 +166,15 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Heldrake2"}),
                   jasmine.objectContaining({'_name': "Heldrake3"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Daemonic Ritual", jasmine.any(String)],
+              ["Brotherhood of Sorcerors", jasmine.any(String)],
+              ["Hateful Assault", jasmine.any(String)],
+              ["Malicious Volleys", jasmine.any(String)],
+              ["Disciples of Tzeentch", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [
@@ -197,7 +205,12 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Magnus the Red2"}),
                   jasmine.objectContaining({'_name': "Magnus the Red3"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Hateful Assault", jasmine.any(String)],
+              ["Malicious Volleys", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/NotZippedSpec.ts
+++ b/spec/NotZippedSpec.ts
@@ -45,7 +45,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Exalted Sorcerer"}),
                 ],
                 '_modelList': [
-                  "Exalted Sorcerer (Inferno Bolt Pistol, Force stave, Frag & Krak grenades, Smite)"
+                  "Exalted Sorcerer (Inferno Bolt Pistol, Force stave [8 pts], Frag & Krak grenades, Smite)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Inferno Bolt Pistol"}),
@@ -82,7 +82,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Rubric Marine"}),
                 ],
                 '_modelList': [
-                  "Aspiring Sorcerer (Inferno Bolt Pistol, Force stave, Smite)",
+                  "Aspiring Sorcerer (Inferno Bolt Pistol, Force stave [8 pts], Smite)",
                   "4x Rubric Marine w/ Inferno Boltgun (Inferno boltgun)"
                 ],
                 '_weapons': [
@@ -118,7 +118,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Helbrute"}),
                 ],
                 '_modelList': [
-                  "Helbrute (Multi-melta, Helbrute fist)"
+                  "Helbrute (Multi-melta [22 pts], Helbrute fist [20 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Multi-melta"}),
@@ -132,8 +132,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Scarab Occult Terminator"}),
                 ],
                 '_modelList': [
-                  "Scarab Occult Sorcerer (Inferno Combi-bolter, Force stave, Smite)",
-                  "4x Terminator (Inferno Combi-bolter, Powersword)"
+                  "Scarab Occult Sorcerer (Inferno Combi-bolter [3 pts], Force stave [8 pts], Smite)",
+                  "4x Terminator (Inferno Combi-bolter [3 pts], Powersword [4 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Inferno Combi-bolter"}),
@@ -154,7 +154,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Heldrake"}),
                 ],
                 '_modelList': [
-                  "Heldrake (Hades Autocannon, Heldrake claws)"
+                  "Heldrake (Hades Autocannon [20 pts], Heldrake claws)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Hades autocannon"}),

--- a/spec/SalamanderstestSpec.ts
+++ b/spec/SalamanderstestSpec.ts
@@ -24,7 +24,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Captain"}),
                 ],
                 '_modelList': [
-                  "Captain (Bolt pistol, Combi-melta, Relic blade, Frag & Krak grenades, Forge Master, Obsidian Aquila, Warlord)"
+                  "Captain (Bolt pistol, Combi-melta [5 pts], Relic blade [10 pts], Frag & Krak grenades, Forge Master, Obsidian Aquila, Warlord)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -44,7 +44,7 @@ describe("Create40kRoster", function() {
                 '_modelList': [
                   "3x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
                   "Space Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                  "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag & Krak grenades)"
+                  "Space Marine w/Special Weapon (Bolt pistol, Flamer [5 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -62,8 +62,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "3x Space Marine (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                  "Space Marine Sergeant (Bolt pistol, 2x Boltgun, Combi-flamer, Frag & Krak grenades)",
-                  "Space Marine w/Special Weapon (Bolt pistol, Flamer, Frag & Krak grenades)"
+                  "Space Marine Sergeant (Bolt pistol, 2x Boltgun [10 pts], Combi-flamer [10 pts], Frag & Krak grenades)",
+                  "Space Marine w/Special Weapon (Bolt pistol, Flamer [5 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -98,8 +98,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "Devastator Marine Sergeant (Bolt pistol, Boltgun, Frag & Krak grenades)",
-                  "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Heavy bolter, Frag & Krak grenades)",
-                  "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Multi-melta, Frag & Krak grenades)"
+                  "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Heavy bolter [10 pts], Frag & Krak grenades)",
+                  "2x Devastator Marine w/Heavy Weapon (Bolt pistol, Multi-melta [20 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),

--- a/spec/SalamanderstestSpec.ts
+++ b/spec/SalamanderstestSpec.ts
@@ -109,7 +109,20 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Frag grenades"}),
                   jasmine.objectContaining({'_name': "Krak grenades"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Combat Doctrines", jasmine.any(String)],
+              ["And They Shall Know No Fear", jasmine.any(String)],
+              ["Bolter Discipline", jasmine.any(String)],
+              ["Angels of Death", jasmine.any(String)],
+              ["Shock Assault", jasmine.any(String)],
+              ["Combi Weapon", jasmine.any(String)],
+              ["Combat Squads", jasmine.any(String)],
+              ["Explodes (6\"/D3)", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
+              ["Forged in Battle", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/SpaceWolvesTestSpec.ts
+++ b/spec/SpaceWolvesTestSpec.ts
@@ -110,8 +110,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Hellblaster Pack Leader"}),
                 ],
                 '_modelList': [
-                  "4x Hellblaster (Bolt pistol, Plasma Incinerator, Frag & Krak grenades)",
-                  "Hellblaster Pack Leader (Bolt pistol, Plasma Incinerator, Frag & Krak grenades)"
+                  "4x Hellblaster (Bolt pistol, Plasma Incinerator [75 pts], Frag & Krak grenades)",
+                  "Hellblaster Pack Leader (Bolt pistol, Plasma Incinerator [75 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -127,7 +127,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Stormfang Gunship"}),
                 ],
                 '_modelList': [
-                  "Stormfang Gunship (Helfrost destructor, 2x Stormstrike missile launcher, 2x Twin heavy bolter)"
+                  "Stormfang Gunship (Helfrost destructor, 2x Stormstrike missile launcher [42 pts], 2x Twin heavy bolter [34 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Helfrost destructor - Dispersed beam"}),
@@ -177,7 +177,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Bjorn the Fell-handed"}),
                 ],
                 '_modelList': [
-                  "Bjorn the Fell-handed (Assault cannon, Heavy flamer, Trueclaw, Warlord)"
+                  "Bjorn the Fell-handed (Assault cannon [22 pts], Heavy flamer [14 pts], Trueclaw, Warlord)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Assault cannon"}),
@@ -191,7 +191,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Primaris Battle Leader"}),
                 ],
                 '_modelList': [
-                  "Primaris Battle Leader (Bolt carbine, Bolt pistol, Power axe, Frag & Krak grenades, Helm of Durfast)"
+                  "Primaris Battle Leader (Bolt carbine, Bolt pistol, Power axe [5 pts], Frag & Krak grenades, Helm of Durfast)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt Carbine"}),
@@ -259,7 +259,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Lone Wolf"}),
                 ],
                 '_modelList': [
-                  "Lone Wolf [Index] (Chainsword, Power axe, Frag & Krak grenades)"
+                  "Lone Wolf [Index] (Chainsword, Power axe [5 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Chainsword"}),
@@ -274,7 +274,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Lone Wolf"}),
                 ],
                 '_modelList': [
-                  "Lone Wolf in Terminator Armour [Index] (Storm bolter, Power sword)"
+                  "Lone Wolf in Terminator Armour [Index] (Storm bolter [2 pts], Power sword [4 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -318,8 +318,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Wulfen Pack Leader"}),
                 ],
                 '_modelList': [
-                  "4x Wulfen (Frost claws, Great frost axe, Thunder Hammer, Wulfen claws)",
-                  "Wulfen Pack Leader (2x Frost claws, Great frost axe, Thunder Hammer, Wulfen claws)"
+                  "4x Wulfen (Frost claws [11 pts], Great frost axe [9 pts], Thunder Hammer [16 pts], Wulfen claws)",
+                  "Wulfen Pack Leader (2x Frost claws [22 pts], Great frost axe [9 pts], Thunder Hammer [16 pts], Wulfen claws)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Frost claws"}),

--- a/spec/SpaceWolvesTestSpec.ts
+++ b/spec/SpaceWolvesTestSpec.ts
@@ -12,7 +12,7 @@ describe("Create40kRoster", function() {
         '_forces': [
           jasmine.objectContaining({
             '_configurations': [
-              "Detachment CP",
+              "Detachment CP [5 CP]",
             ],
             '_units': [
               jasmine.objectContaining({
@@ -165,8 +165,8 @@ describe("Create40kRoster", function() {
           }),
           jasmine.objectContaining({
             '_configurations': [
-              "Battle-forged CP",
-              "Detachment CP",
+              "Battle-forged CP [3 CP]",
+              "Detachment CP [5 CP]",
               "Stratagems - Specialist Detachment: Stalker Pack [-1 CP]",
             ],
             '_units': [

--- a/spec/SpaceWolvesTestSpec.ts
+++ b/spec/SpaceWolvesTestSpec.ts
@@ -152,7 +152,16 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Shock Assault", jasmine.any(String)],
+              ["Bolter Discipline", jasmine.any(String)],
+              ["And They Shall Know No Fear", jasmine.any(String)],
+              ["Hunters Unleashed", jasmine.any(String)],
+              ["Defenders of Humanity", jasmine.any(String)],
+              ["Angels of Death", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [
@@ -318,7 +327,15 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Thunder hammer"}),
                   jasmine.objectContaining({'_name': "Wulfen claws"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["And They Shall Know No Fear", jasmine.any(String)],
+              ["Hunters Unleashed", jasmine.any(String)],
+              ["Defenders of Humanity", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
+              ["Stalker Pack", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/TauTestSpec.ts
+++ b/spec/TauTestSpec.ts
@@ -11,7 +11,10 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 126, _points: 2029, _commandPoints: 15}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Battle-forged CP [3 CP]",
+              "No Force Org Slot - Detachment CP [12 CP]",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Aun'Shi",
@@ -373,30 +376,6 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy rail rifle"}),
                   jasmine.objectContaining({'_name': "Smart missile system"}),
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Battle-forged CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 3}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 12}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
                 ]}),
             ],
             '_rules': new Map([

--- a/spec/TauTestSpec.ts
+++ b/spec/TauTestSpec.ts
@@ -398,7 +398,22 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["For the Greater Good", jasmine.any(String)],
+              ["Pulse blaster", jasmine.any(String)],
+              ["Saviour Protocols", jasmine.any(String)],
+              ["Drone Support", jasmine.any(String)],
+              ["Manta Strike", jasmine.any(String)],
+              ["Hover Tank", jasmine.any(String)],
+              ["Explodes", jasmine.any(String)],
+              ["Attached Drones", jasmine.any(String)],
+              ["Detach", jasmine.any(String)],
+              ["Markerlights", jasmine.any(String)],
+              ["Explodes (Piranha)", jasmine.any(String)],
+              ["Infiltrator", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/TauTestSpec.ts
+++ b/spec/TauTestSpec.ts
@@ -65,10 +65,10 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "MV4 Shield Drone"}),
                 ],
                 '_modelList': [
-                  "DS8 Tactical Support Turret w/ SMS (Smart missile system)",
+                  "DS8 Tactical Support Turret w/ SMS (Smart missile system [15 pts])",
                   "5x Fire Warrior (Pulse blaster, Photon grenades)",
                   "Fire Warrior Shas'ui (Pulse blaster, Photon grenades)",
-                  "2x Fire Warrior w/ Pulse Pistol (Pulse blaster, Pulse pistol, Photon grenades)",
+                  "2x Fire Warrior w/ Pulse Pistol (Pulse blaster, Pulse pistol [1 pts], Photon grenades)",
                   "2x MV4 Shield Drone (Shield generator)"
                 ],
                 '_weapons': [
@@ -90,7 +90,7 @@ describe("Create40kRoster", function() {
                 '_modelList': [
                   "5x Fire Warrior (Pulse blaster, Photon grenades)",
                   "Fire Warrior Shas'ui (Pulse blaster, Photon grenades)",
-                  "Fire Warrior w/ Pulse Pistol (Pulse blaster, Pulse pistol, Photon grenades)",
+                  "Fire Warrior w/ Pulse Pistol (Pulse blaster, Pulse pistol [1 pts], Photon grenades)",
                   "2x MV1 Gun Drone (Pulse carbine)"
                 ],
                 '_weapons': [
@@ -138,10 +138,10 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "MV4 Shield Drone"}),
                 ],
                 '_modelList': [
-                  "DS8 Tactical Support Turret w/ SMS (Smart missile system)",
+                  "DS8 Tactical Support Turret w/ SMS (Smart missile system [15 pts])",
                   "Fire Warrior Shas'ui (Pulse rifle, Photon grenades)",
                   "Fire Warrior w/ Pulse Carbine (Pulse carbine, Photon grenades)",
-                  "Fire Warrior w/ Pulse Pistol + Pulse Rifle (Pulse pistol, Pulse rifle, Photon grenades)",
+                  "Fire Warrior w/ Pulse Pistol + Pulse Rifle (Pulse pistol [1 pts], Pulse rifle, Photon grenades)",
                   "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)",
                   "MV36 Guardian Drone",
                   "MV4 Shield Drone (Shield generator)"
@@ -163,11 +163,11 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "MV4 Shield Drone"}),
                 ],
                 '_modelList': [
-                  "DS8 Tactical Support Turret w/ Missile pod (Missile pod)",
+                  "DS8 Tactical Support Turret w/ Missile pod (Missile pod [15 pts])",
                   "Fire Warrior Shas'ui (Pulse rifle, Photon grenades)",
                   "Fire Warrior w/ Pulse Carbine (Pulse carbine, Photon grenades)",
-                  "Fire Warrior w/ Pulse Pistol + Pulse Carbine (Pulse carbine, Pulse pistol, Photon grenades)",
-                  "Fire Warrior w/ Pulse Pistol + Pulse Rifle (Pulse pistol, Pulse rifle, Photon grenades)",
+                  "Fire Warrior w/ Pulse Pistol + Pulse Carbine (Pulse carbine, Pulse pistol [1 pts], Photon grenades)",
+                  "Fire Warrior w/ Pulse Pistol + Pulse Rifle (Pulse pistol [1 pts], Pulse rifle, Photon grenades)",
                   "5x Fire Warrior w/ Pulse Rifle (Pulse rifle, Photon grenades)",
                   "2x MV4 Shield Drone (Shield generator)"
                 ],
@@ -223,7 +223,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Firesight Marksman"}),
                 ],
                 '_modelList': [
-                  "Firesight Marksman (Markerlight, Pulse pistol, Multi-sensory discouragement array)"
+                  "Firesight Marksman (Markerlight [3 pts], Pulse pistol [1 pts], Multi-sensory discouragement array)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Markerlight"}),
@@ -250,7 +250,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
                 ],
                 '_modelList': [
-                  "XV104 Riptide Battlesuit (Heavy burst cannon, Missile pod, 2x Plasma rifle, Early warning override, Shield generator)"
+                  "XV104 Riptide Battlesuit (Heavy burst cannon [35 pts], Missile pod, 2x Plasma rifle [16 pts], Early warning override [10 pts], Shield generator)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy burst cannon"}),
@@ -272,8 +272,8 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "MV4 Shield Drone (Shield generator)",
-                  "4x Stealth Shas'ui w/ Burst Cannon (Burst cannon)",
-                  "Stealth Shas'vre (Burst cannon)",
+                  "4x Stealth Shas'ui w/ Burst Cannon (Burst cannon [8 pts])",
+                  "Stealth Shas'vre (Burst cannon [8 pts])",
                   "Unit Upgrades (Homing beacon [20 pts])"
                 ],
                 '_weapons': [
@@ -287,7 +287,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "TX4 Piranha"}),
                 ],
                 '_modelList': [
-                  "TX4 Piranha (Burst cannon, 4x Pulse carbine)"
+                  "TX4 Piranha (Burst cannon [8 pts], 4x Pulse carbine)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Burst cannon"}),
@@ -352,7 +352,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "TX7 Hammerhead Gunship"}),
                 ],
                 '_modelList': [
-                  "TX7 Hammerhead Gunship (4x Pulse carbine, Railgun)"
+                  "TX7 Hammerhead Gunship (4x Pulse carbine, Railgun [30 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Pulse carbine"}),
@@ -371,7 +371,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Broadside Shas'ui"}),
                 ],
                 '_modelList': [
-                  "Broadside Shas'ui (Heavy rail rifle, 2x Smart missile system)"
+                  "Broadside Shas'ui (Heavy rail rifle [25 pts], 2x Smart missile system [30 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy rail rifle"}),

--- a/spec/Tau_TestSpec.ts
+++ b/spec/Tau_TestSpec.ts
@@ -34,7 +34,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Commander in XV8 Crisis Battlesuit"}),
                 ],
                 '_modelList': [
-                  "Commander in XV8 Crisis Battlesuit (Burst cannon, Missile pod)"
+                  "Commander in XV8 Crisis Battlesuit (Burst cannon [8 pts], Missile pod [15 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Burst cannon"}),
@@ -47,7 +47,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Commander in XV85 Enforcer Battlesuit"}),
                 ],
                 '_modelList': [
-                  "Commander in XV85 Enforcer Battlesuit (Burst cannon, Missile pod)"
+                  "Commander in XV85 Enforcer Battlesuit (Burst cannon [8 pts], Missile pod [15 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Burst cannon"}),
@@ -114,7 +114,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "XV95 Ghostkeel Shas'vre"}),
                 ],
                 '_modelList': [
-                  "XV95 Ghostkeel Battlesuit (2x Flamer, Fusion collider)"
+                  "XV95 Ghostkeel Battlesuit (2x Flamer [12 pts], Fusion collider [25 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Flamer"}),
@@ -132,7 +132,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "AX3 Razorshark Strike Fighter"}),
                 ],
                 '_modelList': [
-                  "AX3 Razorshark Strike Fighter (Burst cannon, Quad ion turret, 2x Seeker missile)"
+                  "AX3 Razorshark Strike Fighter (Burst cannon [8 pts], Quad ion turret [30 pts], 2x Seeker missile [10 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Burst cannon"}),
@@ -153,7 +153,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "TY7 Devilfish"}),
                 ],
                 '_modelList': [
-                  "TY7 Devilfish (Burst cannon, 4x Pulse carbine)"
+                  "TY7 Devilfish (Burst cannon [8 pts], 4x Pulse carbine)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Burst cannon"}),
@@ -301,7 +301,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
                 ],
                 '_modelList': [
-                  "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
+                  "XV104 Riptide Battlesuit (Heavy burst cannon [35 pts], 2x Smart missile system [30 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy burst cannon"}),
@@ -319,7 +319,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
                 ],
                 '_modelList': [
-                  "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
+                  "XV104 Riptide Battlesuit (Heavy burst cannon [35 pts], 2x Smart missile system [30 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy burst cannon"}),
@@ -337,7 +337,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "XV104 Riptide Battlesuit"}),
                 ],
                 '_modelList': [
-                  "XV104 Riptide Battlesuit (Heavy burst cannon, 2x Smart missile system)"
+                  "XV104 Riptide Battlesuit (Heavy burst cannon [35 pts], 2x Smart missile system [30 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Heavy burst cannon"}),
@@ -415,7 +415,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Heavy Gun Drone"}),
                 ],
                 '_modelList': [
-                  "2x Heavy Gun Drone w/ 2x BC (Burst cannon)"
+                  "2x Heavy Gun Drone w/ 2x BC (Burst cannon [8 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Burst cannon"}),

--- a/spec/Tau_TestSpec.ts
+++ b/spec/Tau_TestSpec.ts
@@ -174,7 +174,23 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["For the Greater Good", jasmine.any(String)],
+              ["Manta Strike", jasmine.any(String)],
+              ["Airborne", jasmine.any(String)],
+              ["Crash and Burn", jasmine.any(String)],
+              ["Hard to Hit", jasmine.any(String)],
+              ["Supersonic", jasmine.any(String)],
+              ["Hover Tank", jasmine.any(String)],
+              ["Explodes", jasmine.any(String)],
+              ["Attached Drones (TY7 Devilfish)", jasmine.any(String)],
+              ["Saviour Protocols", jasmine.any(String)],
+              ["Detach", jasmine.any(String)],
+              ["Drone Support", jasmine.any(String)],
+              ["Infiltrator", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [],
@@ -435,7 +451,16 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["For the Greater Good", jasmine.any(String)],
+              ["Drone Support", jasmine.any(String)],
+              ["Manta Strike", jasmine.any(String)],
+              ["Pulse blaster", jasmine.any(String)],
+              ["Markerlights", jasmine.any(String)],
+              ["Saviour Protocols", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/Tau_TestSpec.ts
+++ b/spec/Tau_TestSpec.ts
@@ -11,7 +11,9 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 138, _points: 1981, _commandPoints: 13}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Detachment CP [5 CP]",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Aun'Shi",
@@ -162,18 +164,6 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "TY7 Devilfish 2"}),
                   jasmine.objectContaining({'_name': "TY7 Devilfish 3"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 5}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
             '_rules': new Map([
               ["For the Greater Good", jasmine.any(String)],
@@ -193,7 +183,10 @@ describe("Create40kRoster", function() {
             '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Battle-forged CP [3 CP]",
+              "No Force Org Slot - Detachment CP [5 CP]",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Commander Farsight",
@@ -426,30 +419,6 @@ describe("Create40kRoster", function() {
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Burst cannon"}),
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Battle-forged CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 3}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 5}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
                 ]}),
             ],
             '_rules': new Map([

--- a/spec/TyranidsTestSpec.ts
+++ b/spec/TyranidsTestSpec.ts
@@ -57,7 +57,7 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Acolyte Hybrid (Autopistol, Cultist Knife, Rending Claw, Blasting Charges)",
-                  "Acolyte Hybrid (Heavy Weapon) (Autopistol, Heavy Rock Saw, Blasting Charges)",
+                  "Acolyte Hybrid (Heavy Weapon) (Autopistol, Heavy Rock Saw [10 pts], Blasting Charges)",
                   "Acolyte Leader (Autopistol, Cultist Knife, Rending Claw, Blasting Charges)"
                 ],
                 '_weapons': [
@@ -77,11 +77,11 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "9x Brood Brother (Lasgun, Frag Grenades)",
-                  "Brood Brother (Flamer) (Flamer, Frag Grenades)",
-                  "Brood Brother (Grenade) (Grenade Launcher, Frag Grenades)",
-                  "Brood Brother (Vox-caster) (Lasgun, Frag Grenades, Cult Vox-caster)",
+                  "Brood Brother (Flamer) (Flamer [6 pts], Frag Grenades)",
+                  "Brood Brother (Grenade) (Grenade Launcher [3 pts], Frag Grenades)",
+                  "Brood Brother (Vox-caster) (Lasgun, Frag Grenades, Cult Vox-caster [5 pts])",
                   "Brood Brothers Leader (Laspistol, Chainsword, Frag Grenades)",
-                  "Brood Brothers Weapons Team (Lascannon, Lasgun, Frag Grenades)"
+                  "Brood Brothers Weapons Team (Lascannon [20 pts], Lasgun, Frag Grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Flamer"}),
@@ -102,9 +102,9 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "9x Neophyte Hybrid (Autogun, Autopistol, Blasting Charges)",
-                  "Neophyte Hybrid (Flamer) (Autopistol, Flamer, Blasting Charges)",
+                  "Neophyte Hybrid (Flamer) (Autopistol, Flamer [6 pts], Blasting Charges)",
                   "Neophyte Hybrid (Lasgun) (Autopistol, Lasgun, Blasting Charges)",
-                  "Neophyte Hybrid (Mining) (Autopistol, Mining Laser, Blasting Charges)",
+                  "Neophyte Hybrid (Mining) (Autopistol, Mining Laser [12 pts], Blasting Charges)",
                   "Neophyte Hybrid (Shotgun) (Autopistol, Shotgun, Blasting Charges)",
                   "Neophyte Leader (Autogun, Autopistol, Blasting Charges)"
                 ],
@@ -126,7 +126,7 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "3x Atalan Jackal (Autopistol, Blasting Charges)",
-                  "Atalan Leader (Autopistol, Power Pick, Blasting Charges, Demolition Charge)"
+                  "Atalan Leader (Autopistol, Power Pick [9 pts], Blasting Charges, Demolition Charge [10 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Autopistol"}),
@@ -141,7 +141,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Cult Leman Russ"}),
                 ],
                 '_modelList': [
-                  "Cult Leman Russ (Battle Cannon, Heavy Bolter, 2x Heavy Flamer, Heavy Stubber, Hunter-killer Missile)"
+                  "Cult Leman Russ (Battle Cannon [22 pts], Heavy Bolter [8 pts], 2x Heavy Flamer [28 pts], Heavy Stubber [2 pts], Hunter-killer Missile [6 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Battle Cannon"}),
@@ -162,7 +162,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Goliath Rockgrinder"}),
                 ],
                 '_modelList': [
-                  "Goliath Rockgrinder (Cache of Demolition Charges, Heavy Mining Laser, Heavy Stubber, Drilldozer Blade)"
+                  "Goliath Rockgrinder (Cache of Demolition Charges [10 pts], Heavy Mining Laser [15 pts], Heavy Stubber [2 pts], Drilldozer Blade)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Cache of Demolition Charges"}),
@@ -217,7 +217,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Hive Tyrant"}),
                 ],
                 '_modelList': [
-                  "Hive Tyrant (2x Monstrous Scything Talons, Prehensile Pincer Tail)"
+                  "Hive Tyrant (2x Monstrous Scything Talons [20 pts], Prehensile Pincer Tail)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Monstrous Scything Talons"}),
@@ -262,11 +262,11 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Tyranid Warrior"}),
                 ],
                 '_modelList': [
-                  "Tyranid Warrior (Devourer, Boneswords)",
-                  "Tyranid Warrior (Devourer, Lash Whip and Bonesword)",
-                  "Tyranid Warrior (Devourer, Rending Claws)",
-                  "Tyranid Warrior (Devourer, Scything Talons)",
-                  "Tyranid Warrior (Bio-cannon) (Venom Cannon, Scything Talons)"
+                  "Tyranid Warrior (Devourer [4 pts], Boneswords [2 pts])",
+                  "Tyranid Warrior (Devourer [4 pts], Lash Whip and Bonesword [2 pts])",
+                  "Tyranid Warrior (Devourer [4 pts], Rending Claws [2 pts])",
+                  "Tyranid Warrior (Devourer [4 pts], Scything Talons)",
+                  "Tyranid Warrior (Bio-cannon) (Venom Cannon [12 pts], Scything Talons)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Devourer"}),
@@ -283,8 +283,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Hive Guard"}),
                 ],
                 '_modelList': [
-                  "3x Hive Guard (Impaler) (Impaler Cannon)",
-                  "Hive Guard (Shock) (Shockcannon)",
+                  "3x Hive Guard (Impaler) (Impaler Cannon [25 pts])",
+                  "Hive Guard (Shock) (Shockcannon [21 pts])",
                   "Unit Upgrades (Adrenal Glands [4 pts], Toxin Sacs [4 pts])"
                 ],
                 '_weapons': [
@@ -298,7 +298,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Carnifex"}),
                 ],
                 '_modelList': [
-                  "Carnifex (2x Monstrous Scything Talons)"
+                  "Carnifex (2x Monstrous Scything Talons [15 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Monstrous Scything Talons"}),

--- a/spec/TyranidsTestSpec.ts
+++ b/spec/TyranidsTestSpec.ts
@@ -175,7 +175,12 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Goliath Rockgrinder (2)"}),
                   jasmine.objectContaining({'_name': "Goliath Rockgrinder (3)"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Cult Ambush", jasmine.any(String)],
+              ["Unquestioning Loyalty", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [],
@@ -389,7 +394,9 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map(),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/TyranidsTestSpec.ts
+++ b/spec/TyranidsTestSpec.ts
@@ -183,7 +183,13 @@ describe("Create40kRoster", function() {
             '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - Battle-forged CP [3 CP]",
+              "No Force Org Slot - Detachment CP [5 CP]",
+              "No Force Org Slot - Hive Fleet: Hydra",
+              "No Force Org Slot - Stratagem: Bounty of the Hive Fleet: 1 Extra Bio-artefact [-1 CP]",
+              "No Force Org Slot - Stratagem: Progeny of the Hive [-1 CP]",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Broodlord",
@@ -334,69 +340,15 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Toxicrene (2)"}),
                   jasmine.objectContaining({'_name': "Toxicrene (3)"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "Battle-forged CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 3}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 5}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Hive Fleet",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  "Unit Upgrades (Hydra)"
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Stratagem: Bounty of the Hive Fleet",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: -1}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  "Unit Upgrades (1 Extra Bio-artefact [-1 CP])"
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Stratagem: Progeny of the Hive",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: -1}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
-            '_rules': new Map(),
-            '_factionRules': new Map(),
+            '_rules': new Map([
+              ["Hive Fleet Adaptations", jasmine.any(String)],
+              ["Bounty of the Hive Fleet", jasmine.any(String)],
+              ["Stratagem: Progeny of the Hive", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
+              ["Swarming Insects", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/XenosTestSpec.ts
+++ b/spec/XenosTestSpec.ts
@@ -146,7 +146,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Blitza-bommer"}),
                 ],
                 '_modelList': [
-                  "Blitza-bommer (Big Shoota, 2x Supa Shoota, Boom Bomb)"
+                  "Blitza-bommer (Big Shoota, 2x Supa Shoota, 2x Boom Bomb)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Big Shoota"}),

--- a/spec/XenosTestSpec.ts
+++ b/spec/XenosTestSpec.ts
@@ -174,7 +174,20 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Dakkajet2"}),
                   jasmine.objectContaining({'_name': "Dakkajet3"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Dis Is Ours! Zog Off!", jasmine.any(String)],
+              ["'Ere We Go!", jasmine.any(String)],
+              ["Mob Rule", jasmine.any(String)],
+              ["Dakka Dakka Dakka", jasmine.any(String)],
+              ["Grots", jasmine.any(String)],
+              ["Airborne", jasmine.any(String)],
+              ["Hard to Hit", jasmine.any(String)],
+              ["Crash and Burn", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
+              ["Bad Moons", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/spec/XenosTestSpec.ts
+++ b/spec/XenosTestSpec.ts
@@ -106,7 +106,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Painboy on Warbike"}),
                 ],
                 '_modelList': [
-                  "Painboy on Warbike [Legends] (2x Dakkagun, 'Urty Syringe, Killsaw, Super Cybork Body)"
+                  "Painboy on Warbike [Legends] (2x Dakkagun, 'Urty Syringe, Killsaw [15 pts], Super Cybork Body)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Dakkagun"}),
@@ -120,7 +120,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Deff Dread"}),
                 ],
                 '_modelList': [
-                  "Deff Dread (2x Big Shoota, 2x Dread Klaw)"
+                  "Deff Dread (2x Big Shoota [10 pts], 2x Dread Klaw [30 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Big Shoota"}),
@@ -133,7 +133,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Killa Kan"}),
                 ],
                 '_modelList': [
-                  "Killa Kan (Big Shoota, Kan Klaw)"
+                  "Killa Kan (Big Shoota [5 pts], Kan Klaw)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Big Shoota"}),
@@ -146,7 +146,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Blitza-bommer"}),
                 ],
                 '_modelList': [
-                  "Blitza-bommer (Big Shoota, 2x Supa Shoota, 2x Boom Bomb)"
+                  "Blitza-bommer (Big Shoota [5 pts], 2x Supa Shoota [20 pts], 2x Boom Bomb)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Big Shoota"}),
@@ -164,7 +164,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Dakkajet"}),
                 ],
                 '_modelList': [
-                  "Dakkajet (4x Supa Shoota)"
+                  "Dakkajet (4x Supa Shoota [40 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Supa Shoota"}),

--- a/spec/helpers/40kRosterExpectation.ts
+++ b/spec/helpers/40kRosterExpectation.ts
@@ -39,7 +39,9 @@ function processForces(forces: Force[]): string {
           jasmine.objectContaining({
             '_configurations': [${processConfigurations(force._configurations)}],
             '_units': [${processUnits(force._units)}
-            ]
+            ],
+            '_rules': new Map(${processRulesMap(force._rules)}),
+            '_factionRules': new Map(${processRulesMap(force._factionRules)}),
           }),`).join('');
 }
 
@@ -102,3 +104,11 @@ function processOptionalUnitStats(unit: Unit) {
   }
   return output;
 }
+
+function processRulesMap(_rules: Map<string, string | null>): string {
+  if (_rules.size === 0) return '';
+  return '[\n' +
+    Array.from(_rules.keys()).map(key => `              [${JSON.stringify(key)}, jasmine.any(String)],\n`).join('') +
+  '            ]';
+}
+

--- a/spec/longweaponnamesSpec.ts
+++ b/spec/longweaponnamesSpec.ts
@@ -35,7 +35,14 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Hellforged heavy plasma cannon - Standard"}),
                   jasmine.objectContaining({'_name': "Hellforged heavy plasma cannon - Supercharge"}),
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Daemonic Ritual", jasmine.any(String)],
+              ["Hateful Assault", jasmine.any(String)],
+              ["Martial Legacy", jasmine.any(String)],
+              ["Malicious Volleys", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/longweaponnamesSpec.ts
+++ b/spec/longweaponnamesSpec.ts
@@ -22,7 +22,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Chaos Contemptor Dreadnought"}),
                 ],
                 '_modelList': [
-                  "Chaos Contemptor Dreadnought (Conversion beam cannon, Hellforged cyclone missile launcher, Hellforged heavy plasma cannon)"
+                  "Chaos Contemptor Dreadnought (Conversion beam cannon [5 pts], Hellforged cyclone missile launcher [25 pts], Hellforged heavy plasma cannon)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Conversion beam cannon 1 - Short range"}),

--- a/spec/rosterSpec.ts
+++ b/spec/rosterSpec.ts
@@ -223,7 +223,14 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Bolter Discipline", jasmine.any(String)],
+              ["Angels of Death", jasmine.any(String)],
+              ["Shock Assault", jasmine.any(String)],
+              ["Righteous Zeal", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
             '_configurations': [],
@@ -400,7 +407,14 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   
                 ]}),
-            ]
+            ],
+            '_rules': new Map([
+              ["Righteous Zeal", jasmine.any(String)],
+              ["Angels of Death", jasmine.any(String)],
+              ["Explodes (6\"/D6)", jasmine.any(String)],
+              ["Explodes (6\"/D3)", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map(),
           }),
         ]}));
   });

--- a/spec/rosterSpec.ts
+++ b/spec/rosterSpec.ts
@@ -24,7 +24,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Captain in Phobos Armour"}),
                 ],
                 '_modelList': [
-                  "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine, Combat knife, Frag & Krak grenades, Camo cloak, Frontline Commander, The Aurillian Shroud, Warlord)"
+                  "Captain in Phobos Armour (Bolt pistol, Master-crafted instigator bolt carbine [6 pts], Combat knife, Frag & Krak grenades, Camo cloak [3 pts], Frontline Commander, The Aurillian Shroud, Warlord)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -57,7 +57,7 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Initiate w/Chainsword (Bolt pistol, Chainsword, Frag & Krak grenades)",
-                  "Sword Brother (Bolt pistol, Power fist, Frag & Krak grenades)"
+                  "Sword Brother (Bolt pistol, Power fist [9 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -92,7 +92,7 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag & Krak grenades)",
-                  "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag & Krak grenades)"
+                  "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer [16 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -110,7 +110,7 @@ describe("Create40kRoster", function() {
                 ],
                 '_modelList': [
                   "4x Intercessor (Bolt pistol, Stalker Bolt Rifle, Frag & Krak grenades)",
-                  "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer, Frag & Krak grenades)"
+                  "Intercessor Sergeant (Bolt pistol, Stalker Bolt Rifle, Thunder hammer [16 pts], Frag & Krak grenades)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -127,7 +127,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Veteran Sergeant (Jump Pack)"}),
                 ],
                 '_modelList': [
-                  "Vanguard Veteran Squad (Grav-pistol, Relic blade, 4x Thunder hammer, 5x Frag & Krak grenades, Jump Pack, 4x Storm shield)"
+                  "Vanguard Veteran Squad (Grav-pistol [8 pts], Relic blade [9 pts], 4x Thunder hammer [64 pts], 5x Frag & Krak grenades, Jump Pack [15 pts / 1 PL], 4x Storm shield [8 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Grav-pistol"}),
@@ -144,7 +144,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
                 ],
                 '_modelList': [
-                  "Assault Squad (2x Bolt pistol, 3x Plasma pistol, 5x Chainsword, 5x Frag & Krak grenades, Jump Pack)"
+                  "Assault Squad (2x Bolt pistol, 3x Plasma pistol [15 pts], 5x Chainsword, 5x Frag & Krak grenades, Jump Pack [15 pts / 1 PL])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -162,8 +162,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Suppressor Sergeant"}),
                 ],
                 '_modelList': [
-                  "2x Suppressor (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)",
-                  "Suppressor Sergeant (Accelerator autocannon, Bolt pistol, Frag & Krak grenades, Grav-chute)"
+                  "2x Suppressor (Accelerator autocannon [10 pts], Bolt pistol, Frag & Krak grenades, Grav-chute [2 pts])",
+                  "Suppressor Sergeant (Accelerator autocannon [10 pts], Bolt pistol, Frag & Krak grenades, Grav-chute [2 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Accelerator autocannon"}),
@@ -179,8 +179,8 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Eliminator Sergeant"}),
                 ],
                 '_modelList': [
-                  "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)",
-                  "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle, Frag & Krak grenades, Camo cloak)"
+                  "Eliminator Sergeant (Bolt pistol, Bolt sniper rifle [3 pts], Frag & Krak grenades, Camo cloak [3 pts])",
+                  "2x Eliminator with Bolt Sniper (Bolt pistol, Bolt sniper rifle [3 pts], Frag & Krak grenades, Camo cloak [3 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -247,7 +247,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Redemptor Dreadnought"}),
                 ],
                 '_modelList': [
-                  "Redemptor Dreadnought (2x Fragstorm Grenade Launchers, Heavy flamer, Heavy Onslaught Gatling Cannon, Redemptor Fist)"
+                  "Redemptor Dreadnought (2x Fragstorm Grenade Launchers [8 pts], Heavy flamer [14 pts], Heavy Onslaught Gatling Cannon [30 pts], Redemptor Fist)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
@@ -268,7 +268,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Space Marine Sergeant"}),
                 ],
                 '_modelList': [
-                  "Devastator Squad (7x Bolt pistol, Boltgun, 4x Grav-cannon and grav-amp, Chainsword, 6x Frag & Krak grenades, Armorium Cherub)"
+                  "Devastator Squad (7x Bolt pistol, Boltgun, 4x Grav-cannon and grav-amp [80 pts], Chainsword, 6x Frag & Krak grenades, Armorium Cherub [5 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),
@@ -285,7 +285,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Repulsor Executioner"}),
                 ],
                 '_modelList': [
-                  "Repulsor Executioner (2x Fragstorm Grenade Launcher, Heavy Laser Destroyer, Heavy Onslaught Gatling Cannon, Ironhail Heavy Stubber, 2x Storm bolter, Twin Heavy Bolter, Twin Icarus Ironhail Heavy Stubber, Auto Launchers)"
+                  "Repulsor Executioner (2x Fragstorm Grenade Launcher [8 pts], Heavy Laser Destroyer [40 pts], Heavy Onslaught Gatling Cannon [30 pts], Ironhail Heavy Stubber [6 pts], 2x Storm bolter [4 pts], Twin Heavy Bolter [17 pts], Twin Icarus Ironhail Heavy Stubber [10 pts], Auto Launchers)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Fragstorm Grenade Launcher"}),
@@ -308,7 +308,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Drop Pod"}),
                 ],
                 '_modelList': [
-                  "Drop Pod (Storm bolter)"
+                  "Drop Pod (Storm bolter [2 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Storm bolter"}),
@@ -320,7 +320,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Impulsor"}),
                 ],
                 '_modelList': [
-                  "Impulsor (Ironhail Heavy Stubber, Ironhail Skytalon Array, 2x Storm Bolters)"
+                  "Impulsor (Ironhail Heavy Stubber [6 pts], Ironhail Skytalon Array [5 pts], 2x Storm Bolters [4 pts])"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Ironhail Heavy Stubber"}),

--- a/spec/rosterSpec.ts
+++ b/spec/rosterSpec.ts
@@ -127,7 +127,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Veteran Sergeant (Jump Pack)"}),
                 ],
                 '_modelList': [
-                  "Vanguard Veteran Squad (Grav-pistol, Relic blade, 4x Thunder hammer, 5x Frag & Krak grenades, Jump Pack, Storm shield, Storm shield, Storm shield, Storm shield)"
+                  "Vanguard Veteran Squad (Grav-pistol, Relic blade, 4x Thunder hammer, 5x Frag & Krak grenades, Jump Pack, 4x Storm shield)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Grav-pistol"}),
@@ -144,7 +144,7 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Space Marine Sergeant (Jump Pack)"}),
                 ],
                 '_modelList': [
-                  "Assault Squad (2x Bolt pistol, 3x Plasma pistol, 4x Chainsword, 4x Frag & Krak grenades, Jump Pack)"
+                  "Assault Squad (2x Bolt pistol, 3x Plasma pistol, 5x Chainsword, 5x Frag & Krak grenades, Jump Pack)"
                 ],
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Bolt pistol"}),

--- a/spec/rosterSpec.ts
+++ b/spec/rosterSpec.ts
@@ -11,7 +11,11 @@ describe("Create40kRoster", function() {
         '_cost': jasmine.objectContaining({_powerLevel: 100, _points: 1998, _commandPoints: 8}),
         '_forces': [
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - **Chapter Selection**: Imperial Fists Successor, Black Templars",
+              "No Force Org Slot - Battle-forged CP [3 CP]",
+              "No Force Org Slot - Detachment CP [5 CP]",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Captain in Phobos Armour",
@@ -187,53 +191,22 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Frag grenade"}),
                   jasmine.objectContaining({'_name': "Krak grenade"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "**Chapter Selection**",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Battle-forged CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 3}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 5}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
             '_rules': new Map([
               ["Bolter Discipline", jasmine.any(String)],
               ["Angels of Death", jasmine.any(String)],
               ["Shock Assault", jasmine.any(String)],
+            ]),
+            '_factionRules': new Map([
               ["Righteous Zeal", jasmine.any(String)],
             ]),
-            '_factionRules': new Map(),
           }),
           jasmine.objectContaining({
-            '_configurations': [],
+            '_configurations': [
+              "No Force Org Slot - **Chapter Selection**: Imperial Fists Successor, Black Templars",
+              "No Force Org Slot - Detachment CP [1 CP]",
+              "No Force Org Slot - Relics of the Chapter: Number of extra Relics [-1 CP]",
+            ],
             '_units': [
               jasmine.objectContaining({
                 '_name': "Chaplain Grimaldus",
@@ -360,18 +333,6 @@ describe("Create40kRoster", function() {
                   jasmine.objectContaining({'_name': "Impulsor Wound Track 3"}),
                 ]}),
               jasmine.objectContaining({
-                '_name': "**Chapter Selection**",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 0}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
                 '_name': "Cenobyte Servitors",
                 '_cost': jasmine.objectContaining({_powerLevel: 1, _points: 6, _commandPoints: 0}),
                 '_modelStats': [
@@ -383,38 +344,15 @@ describe("Create40kRoster", function() {
                 '_weapons': [
                   jasmine.objectContaining({'_name': "Close Combat Weapon"}),
                 ]}),
-              jasmine.objectContaining({
-                '_name': "Detachment CP",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: 1}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
-              jasmine.objectContaining({
-                '_name': "Relics of the Chapter",
-                '_cost': jasmine.objectContaining({_powerLevel: 0, _points: 0, _commandPoints: -1}),
-                '_modelStats': [
-                  
-                ],
-                '_modelList': [
-                  
-                ],
-                '_weapons': [
-                  
-                ]}),
             ],
             '_rules': new Map([
-              ["Righteous Zeal", jasmine.any(String)],
               ["Angels of Death", jasmine.any(String)],
               ["Explodes (6\"/D6)", jasmine.any(String)],
               ["Explodes (6\"/D3)", jasmine.any(String)],
             ]),
-            '_factionRules': new Map(),
+            '_factionRules': new Map([
+              ["Righteous Zeal", jasmine.any(String)],
+            ]),
           }),
         ]}));
   });

--- a/src/roster40k.ts
+++ b/src/roster40k.ts
@@ -797,9 +797,6 @@ function ParseUnit(root: Element, is40k: boolean): Unit {
                 const upgrade = new Upgrade();
                 upgrade._name = upgradeName;
                 upgrade._cost = GetSelectionCosts(upgradeSelection);
-                // TODO display pts + PL cost once UI can toggle them on/off; we
-                // keep track of CP to make this change backward-compatible.
-                upgrade._cost._points = upgrade._cost._powerLevel = 0;
                 upgrade._count = Number(upgradeSelection.getAttribute('number'));
                 model._upgrades.push(upgrade);
             }
@@ -992,8 +989,7 @@ function ParseWeaponProfile(profile: Element): Weapon {
     const selectionName = selection?.getAttribute('name');
     if (selection?.getAttribute('type') === 'upgrade' && selectionName) {
         weapon._selectionName = selectionName;
-        // TODO Track weapon costs, as well as an option to toggle on/off.
-        // weapon._cost = GetSelectionCosts(selection);
+        weapon._cost = GetSelectionCosts(selection);
     }
     return weapon;
 }

--- a/src/roster40k.ts
+++ b/src/roster40k.ts
@@ -203,17 +203,20 @@ export class Model extends BaseNotes {
         let name = super.name();
 
         if (this._weapons.length > 0 || this._upgrades.length > 0) {
-            const selectionNames: string[] = [];
-            const gear: string[] = [];
-            for (const upgrade of [...this._weapons, ...this._upgrades]) {
-                const name = upgrade.selectionName();
-                if (selectionNames.includes(name)) continue;
-                selectionNames.push(name);
-                gear.push(upgrade.toString());
-            }
-            name += ` (${gear.join(', ')})`;
+            const gear = this.getDedupedWeaponsAndUpgrades();
+            name += ` (${gear.map(u => u.toString()).join(', ')})`;
         }
         return name;
+    }
+
+    getDedupedWeaponsAndUpgrades(): Upgrade[] {
+        const deduped: Upgrade[] = [];
+        for (const upgrade of [...this._weapons, ...this._upgrades]) {
+            if (!deduped.some(e => upgrade.selectionName() === e.selectionName())) {
+                deduped.push(upgrade);
+            }
+        }
+        return deduped;
     }
 
     normalize(): void {


### PR DESCRIPTION
For 40k, provide an option to toggle weapon and upgrade costs on or off.

Fixed some minor cost/count issues along the way, and cleaned up/fixed configuration values for older rosters to show as configs and not units.