### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -229,7 +229,7 @@ function handleFileSelect(event: Event) {
 }
 
 function showErrorModal(msg: string) {
-  $('#errorText').html(msg);
+  $('#errorText').text(msg);
   $('#errorDialog').modal('show');  
 
 }


### PR DESCRIPTION
Potential fix for [https://github.com/rweyrauch/PrettyScribe/security/code-scanning/4](https://github.com/rweyrauch/PrettyScribe/security/code-scanning/4)

In general, the fix is to ensure that any untrusted text is not interpreted as HTML. Instead of inserting it with `.html()` (or `innerHTML`), which parses HTML and can execute scripts, we should use a text-only API such as jQuery’s `.text()` so that any HTML metacharacters are escaped and shown literally. Alternatively, we could sanitize/encode the string before using `.html()`, but that is more complex and unnecessary here.

The single best minimal-change fix here is:

- In `showErrorModal`, replace `$('#errorText').html(msg);` with `$('#errorText').text(msg);`.
- This preserves all existing functionality (the error message is still displayed) but ensures that values like `file.name` cannot inject HTML/JS.
- No other parts of the file need to change, and no new imports or helpers are required.
- This change addresses all three CodeQL alert variants, since they all flow into the same `msg` used in `showErrorModal`.

This edit is localized to `src/app.ts` around line 231–235.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
