### PR TITLE
Potential fix for code scanning alert no. 2: Useless regular-expression character escape

### DIFF
--- a/tools/write40kRosterExpectation.ts
+++ b/tools/write40kRosterExpectation.ts
@@ -26,7 +26,7 @@ const INPUT_SUBDIR_TO_EXPECTATIONS: { [key: string]: (filename: string) => Promi
 const OUTPUT_DIRECTORY = 'spec';
 
 async function writeRosterExpectations(filename: string) {
-  const filenameMatch = filename.match(`${INPUT_DIRECTORY}/(?:([^/]+)/)?([^/]+)\.(rosz?|regi[sz]try)$`);
+  const filenameMatch = filename.match(`${INPUT_DIRECTORY}/(?:([^/]+)/)?([^/]+)\\.(rosz?|regi[sz]try)$`);
   if (!filenameMatch) {
     throw new Error(`ERROR: Unexpected input filename doesn't match regex: ${filename}`);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/rweyrauch/PrettyScribe/security/code-scanning/2](https://github.com/rweyrauch/PrettyScribe/security/code-scanning/2)

In general, when constructing a `RegExp` from a string, any backslash that you intend the regex engine to see must itself be escaped for the string literal. That means `\.` in a regex literal becomes `\\.` in a string passed to `RegExp`. Here, on line 29, we want to match a literal dot before the extensions `(rosz?|regi[sz]try)`. Currently the string has `\.`; the JS parser turns that into `.`, so the regex engine sees an unescaped meta-character. The minimal, behavior-preserving fix is to change `\.` to `\\.` within that string template. No imports or additional definitions are needed; we only adjust the regex string in `writeRosterExpectations` in `tools/write40kRosterExpectation.ts`.

Concretely:
- Edit line 29 so that the pattern becomes:
  ```ts
  `${INPUT_DIRECTORY}/(?:([^/]+)/)?([^/]+)\\.(rosz?|regi[sz]try)$`
  ```
- This ensures the final regular expression has `\.` (literal dot), keeping all other behavior the same.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
